### PR TITLE
Fix default CSP setting for Ace Editor

### DIFF
--- a/src/couch_httpd_misc_handlers.erl
+++ b/src/couch_httpd_misc_handlers.erl
@@ -81,7 +81,7 @@ handle_utils_dir_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
 maybe_add_csp_headers(Headers, "true") ->
-    DefaultValues = "default-src 'self'; img-src 'self'; font-src 'self'; "
+    DefaultValues = "default-src 'self'; img-src 'self' data:; font-src 'self'; "
                     "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
     Value = config:get("csp", "header_value", DefaultValues),
     [{"Content-Security-Policy", Value} | Headers];

--- a/test/couchdb_csp_tests.erl
+++ b/test/couchdb_csp_tests.erl
@@ -57,7 +57,7 @@ should_not_return_any_csp_headers_when_disabled(Url) ->
 
 should_apply_default_policy(Url) ->
     ?_assertEqual(
-        "default-src 'self'; img-src 'self'; font-src 'self'; "
+        "default-src 'self'; img-src 'self' data:; font-src 'self'; "
         "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
         begin
             {ok, _, Headers, _} = test_request:get(Url),


### PR DESCRIPTION
Like @sebastianrothbucher noticed in apache/couchdb-fauxton#5
the Ace editor needs base64 image data as image source for their
icons

~~Please don't merge: I think I have to fix a test before this can get merged in apache/couchdb - will do that once eunit is merged and the travis builds are green again~~
