### PR TITLE
Respond with HTTP 400 Bad Request on invalid revision number

### DIFF
--- a/src/couch_doc.erl
+++ b/src/couch_doc.erl
@@ -140,7 +140,13 @@ parse_rev(Rev) when is_binary(Rev) ->
 parse_rev(Rev) when is_list(Rev) ->
     SplitRev = lists:splitwith(fun($-) -> false; (_) -> true end, Rev),
     case SplitRev of
-        {Pos, [$- | RevId]} -> {list_to_integer(Pos), parse_revid(RevId)};
+        {Pos, [$- | RevId]} ->
+            IntPos = try list_to_integer(Pos) of
+                Val -> Val
+            catch
+                error:badarg -> throw({bad_request, <<"Invalid rev format">>})
+            end,
+            {IntPos, parse_revid(RevId)};
         _Else -> throw({bad_request, <<"Invalid rev format">>})
     end;
 parse_rev(_BadRev) ->

--- a/test/couch_doc_tests.erl
+++ b/test/couch_doc_tests.erl
@@ -1,0 +1,22 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_doc_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+
+parse_rev_test() ->
+    ?assertEqual({1, <<"123">>}, couch_doc:parse_rev("1-123")),
+    ?assertEqual({1, <<"123">>}, couch_doc:parse_rev(<<"1-123">>)),
+    ?assertException(throw, {bad_request, _}, couch_doc:parse_rev("1f-123")),
+    ?assertException(throw, {bad_request, _}, couch_doc:parse_rev("bar")).


### PR DESCRIPTION
CouchDB should return HTTP 400 instead of HTTP 500 response
when revision number isn't integer like "foo-bar" as like as it does
for completely invalid revisions like "foo".

COUCHDB-2375
