### PR TITLE
Fix header for documents with newlines in the name

### DIFF
--- a/src/couch_httpd_db.erl
+++ b/src/couch_httpd_db.erl
@@ -721,7 +721,7 @@ update_doc_result_to_json(DocId, Error) ->
 
 
 update_doc(Req, Db, DocId, #doc{deleted=false}=Doc) ->
-    Loc = absolute_uri(Req, "/" ++ ?b2l(Db#db.name) ++ "/" ++ ?b2l(DocId)),
+    Loc = absolute_uri(Req, "/" ++ ?b2l(Db#db.name) ++ "/" ++ couch_util:url_encode(DocId)),
     update_doc(Req, Db, DocId, Doc, [{"Location", Loc}]);
 update_doc(Req, Db, DocId, Doc) ->
     update_doc(Req, Db, DocId, Doc, []).
@@ -1022,7 +1022,7 @@ db_attachment_req(#httpd{method=Method,mochi_req=MochiReq}=Req, Db, DocId, FileN
     _ ->
         [{"Location", absolute_uri(Req, "/" ++
             ?b2l(Db#db.name) ++ "/" ++
-            ?b2l(DocId) ++ "/" ++
+            couch_util:url_encode(DocId) ++ "/" ++
             ?b2l(FileName)
         )}]
     end,
@@ -1233,4 +1233,3 @@ validate_attachment_name(Name) ->
         true -> Name;
         false -> throw({bad_request, <<"Attachment name is not UTF-8 encoded">>})
     end.
-

--- a/test/couchdb_location_header_tests.erl
+++ b/test/couchdb_location_header_tests.erl
@@ -1,0 +1,78 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couchdb_location_header_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(TIMEOUT, 1000).
+
+
+setup() ->
+    DbName = ?tempdb(),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    couch_db:close(Db),
+
+    Addr = config:get("httpd", "bind_address", "127.0.0.1"),
+    Port = integer_to_list(mochiweb_socket_server:get(couch_httpd, port)),
+    Host = "http://" ++ Addr ++ ":" ++ Port,
+    {Host, ?b2l(DbName)}.
+
+teardown({_, DbName}) ->
+    ok = couch_server:delete(?l2b(DbName), [?ADMIN_USER]),
+    ok.
+
+
+header_test_() ->
+    {
+        "CouchDB Location Header Tests",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_work_with_newlines_in_docs/1,
+                    fun should_work_with_newlines_in_attachments/1
+                ]
+            }
+        }
+    }.
+
+should_work_with_newlines_in_docs({Host, DbName}) ->
+    Url = Host ++ "/" ++ DbName ++ "/docid%0A",
+    {"COUCHDB-708",
+        ?_assertEqual(
+            Url,
+            begin
+                {ok, _, Headers, _} = test_request:put(Url,
+                    [{"Content-Type", "application/json"}], "{}"),
+                proplists:get_value("Location", Headers)
+            end)}.
+
+should_work_with_newlines_in_attachments({Host, DbName}) ->
+    Url = Host ++ "/" ++ DbName,
+    AttUrl = Url ++ "/docid%0A/readme.txt",
+    {"COUCHDB-708",
+        ?_assertEqual(
+            AttUrl,
+            begin
+                Body = "We all live in a yellow submarine!",
+                Headers0 = [
+                    {"Content-Length", "34"},
+                    {"Content-Type", "text/plain"}
+                ],
+                {ok, _, Headers, _} = test_request:put(AttUrl, Headers0, Body),
+                proplists:get_value("Location", Headers)
+            end)}.


### PR DESCRIPTION
Properly urlencode the Document-Id in the Location field of the
header

Based on a patch from Sean Bartell wingedtachikoma@gmail.com

Added some eunit-tests

COUCHDB-708
