### PR TITLE
Implement two factor authentication

### DIFF
--- a/src/couch_hotp.erl
+++ b/src/couch_hotp.erl
@@ -1,0 +1,40 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_hotp).
+
+-export([generate/4]).
+
+generate(Alg, Key, Counter, OutputLen)
+  when is_atom(Alg), is_binary(Key), is_integer(Counter), is_integer(OutputLen) ->
+    Hmac = hmac(Alg, Key, <<Counter:64>>),
+    Offset = binary:last(Hmac) band 16#f,
+    Code =
+        ((binary:at(Hmac, Offset) band 16#7f) bsl 24) +
+        ((binary:at(Hmac, Offset + 1) band 16#ff) bsl 16) +
+        ((binary:at(Hmac, Offset + 2) band 16#ff) bsl 8) +
+        ((binary:at(Hmac, Offset + 3) band 16#ff)),
+    case OutputLen of
+        6 -> Code rem 1000000;
+        7 -> Code rem 10000000;
+        8 -> Code rem 100000000
+    end.
+
+hmac(Alg, Key, Data) ->
+    case {Alg, erlang:function_exported(crypto, hmac, 3)} of
+        {_, true} ->
+            crypto:hmac(Alg, Key, Data);
+        {sha, false} ->
+            crypto:sha_mac(Key, Data);
+        {Alg, false} ->
+            throw({unsupported, Alg})
+    end.

--- a/src/couch_totp.erl
+++ b/src/couch_totp.erl
@@ -1,0 +1,23 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_totp).
+
+-export([generate/5]).
+
+generate(Alg, Key, CounterSecs, StepSecs, OutputLen)
+  when is_atom(Alg),
+       is_binary(Key),
+       is_integer(CounterSecs),
+       is_integer(StepSecs),
+       is_integer(OutputLen) ->
+    couch_hotp:generate(Alg, Key, CounterSecs div StepSecs, OutputLen).

--- a/test/couch_hotp_tests.erl
+++ b/test/couch_hotp_tests.erl
@@ -1,0 +1,28 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_hotp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+hotp_test() ->
+    Key = <<"12345678901234567890">>,
+    ?assertEqual(755224, couch_hotp:generate(sha, Key, 0, 6)),
+    ?assertEqual(287082, couch_hotp:generate(sha, Key, 1, 6)),
+    ?assertEqual(359152, couch_hotp:generate(sha, Key, 2, 6)),
+    ?assertEqual(969429, couch_hotp:generate(sha, Key, 3, 6)),
+    ?assertEqual(338314, couch_hotp:generate(sha, Key, 4, 6)),
+    ?assertEqual(254676, couch_hotp:generate(sha, Key, 5, 6)),
+    ?assertEqual(287922, couch_hotp:generate(sha, Key, 6, 6)),
+    ?assertEqual(162583, couch_hotp:generate(sha, Key, 7, 6)),
+    ?assertEqual(399871, couch_hotp:generate(sha, Key, 8, 6)),
+    ?assertEqual(520489, couch_hotp:generate(sha, Key, 9, 6)).

--- a/test/couch_totp_tests.erl
+++ b/test/couch_totp_tests.erl
@@ -1,0 +1,55 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_totp_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+totp_sha_test() ->
+    Key = <<"12345678901234567890">>,
+    ?assertEqual(94287082, couch_totp:generate(sha, Key, 59, 30, 8)),
+    ?assertEqual(07081804, couch_totp:generate(sha, Key, 1111111109, 30, 8)),
+    ?assertEqual(14050471, couch_totp:generate(sha, Key, 1111111111, 30, 8)),
+    ?assertEqual(89005924, couch_totp:generate(sha, Key, 1234567890, 30, 8)),
+    ?assertEqual(69279037, couch_totp:generate(sha, Key, 2000000000, 30, 8)),
+    ?assertEqual(65353130, couch_totp:generate(sha, Key, 20000000000, 30, 8)).
+
+totp_sha256_test() ->
+    Key = <<"12345678901234567890123456789012">>,
+    case sha_256_512_supported() of
+        true ->
+            ?assertEqual(46119246, couch_totp:generate(sha256, Key, 59, 30, 8)),
+            ?assertEqual(68084774, couch_totp:generate(sha256, Key, 1111111109, 30, 8)),
+            ?assertEqual(67062674, couch_totp:generate(sha256, Key, 1111111111, 30, 8)),
+            ?assertEqual(91819424, couch_totp:generate(sha256, Key, 1234567890, 30, 8)),
+            ?assertEqual(90698825, couch_totp:generate(sha256, Key, 2000000000, 30, 8)),
+            ?assertEqual(77737706, couch_totp:generate(sha256, Key, 20000000000, 30, 8));
+        false ->
+            ?debugMsg("sha256 not supported, tests skipped")
+    end.
+
+totp_sha512_test() ->
+    Key = <<"1234567890123456789012345678901234567890123456789012345678901234">>,
+    case sha_256_512_supported() of
+        true ->
+            ?assertEqual(90693936, couch_totp:generate(sha512, Key, 59, 30, 8)),
+            ?assertEqual(25091201, couch_totp:generate(sha512, Key, 1111111109, 30, 8)),
+            ?assertEqual(99943326, couch_totp:generate(sha512, Key, 1111111111, 30, 8)),
+            ?assertEqual(93441116, couch_totp:generate(sha512, Key, 1234567890, 30, 8)),
+            ?assertEqual(38618901, couch_totp:generate(sha512, Key, 2000000000, 30, 8)),
+            ?assertEqual(47863826, couch_totp:generate(sha512, Key, 20000000000, 30, 8));
+        false ->
+            ?debugMsg("sha512 not supported, tests skipped")
+    end.
+
+sha_256_512_supported() ->
+    erlang:function_exported(crypto, hmac, 3).


### PR DESCRIPTION
If enabled, require a second factor to acquire a session cookie and
reject basic authentication attempts (as second factor cannot be
presented). Allow previous and next token for clock skew.

To enable this, you add a "totp" object to your user doc with a secret
"key" value.
