### PR TITLE
Allow couch_httpd_cors to be disable by the calling process

### DIFF
--- a/src/couch_httpd_cors.erl
+++ b/src/couch_httpd_cors.erl
@@ -309,7 +309,12 @@ cors_section(Host0) ->
     "cors:" ++ Host.
 
 enable_cors() ->
-    get_bool_config("httpd", "enable_cors", false).
+    case get('disable_couch_httpd_cors') of
+        undefined ->
+            get_bool_config("httpd", "enable_cors", false);
+        _ ->
+            false
+    end.
 
 get_bool_config(Section, Key, Default) ->
     case config:get(Section, Key) of


### PR DESCRIPTION
In chttpd we call into couch_httpd for the low level http functions
like send_json. The function couch_httpd:send_response/4 calls out to
couch_httpd_cors, which will cause duplicate CORS headers to be set
when we've already gone through chttpd_cors.

This is a bit of a hack but it's a good temporary measure until we
consolidate couch_httpd and chttpd down to one http stack.
