### PR TITLE
Return username on POST to /_session

### DIFF
--- a/src/couch_httpd_auth.erl
+++ b/src/couch_httpd_auth.erl
@@ -314,7 +314,7 @@ handle_session_req(#httpd{method='POST', mochi_req=MochiReq}=Req, AuthModule) ->
             send_json(Req#httpd{req_body=ReqBody}, Code, Headers,
                 {[
                     {ok, true},
-                    {name, couch_util:get_value(<<"name">>, UserProps2, null)},
+                    {name, UserName},
                     {roles, couch_util:get_value(<<"roles">>, UserProps2, [])}
                 ]});
         _Else ->

--- a/src/test_request.erl
+++ b/src/test_request.erl
@@ -13,7 +13,7 @@
 -module(test_request).
 
 -export([get/1, get/2, get/3]).
--export([post/3]).
+-export([post/2, post/3]).
 -export([put/2, put/3]).
 -export([delete/1]).
 -export([options/1, options/2, options/3]).
@@ -26,6 +26,9 @@ get(Url, Headers) ->
     request(get, Url, Headers).
 get(Url, Headers, Opts) ->
     request(get, Url, Headers, [], Opts).
+
+post(Url, Body) ->
+    request(post, Url, [], Body).
 
 post(Url, Headers, Body) ->
     request(post, Url, Headers, Body).

--- a/test/couchdb_auth_tests.erl
+++ b/test/couchdb_auth_tests.erl
@@ -1,0 +1,51 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couchdb_auth_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+
+setup() ->
+    Addr = config:get("httpd", "bind_address", "127.0.0.1"),
+    Port = integer_to_list(mochiweb_socket_server:get(couch_httpd, port)),
+    lists:concat(["http://", Addr, ":", Port, "/_session"]).
+
+teardown(_) ->
+    ok.
+
+
+auth_test_() ->
+    {
+        "Auth tests",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_not_return_username_on_post_to_session/1
+                ]
+            }
+        }
+    }.
+
+should_not_return_username_on_post_to_session(Url) ->
+    ?_assertEqual(<<"rocko">>,
+        begin
+            ok = config:set("admins", "rocko", "artischocko", false),
+            {ok, _, _, Body} = test_request:post(Url, [{"Content-Type", "application/json"}],
+                "{\"name\":\"rocko\", \"password\":\"artischocko\"}"),
+            {Json} = jiffy:decode(Body),
+            proplists:get_value(<<"name">>, Json)
+        end).


### PR DESCRIPTION
When logging in with admin credentials and no user doc is
present, the name was `null`. Example:

`{"ok":true,"name":null,"roles":["_admin"]}`

closes COUCHDB-1356
