### PR TITLE
Expose and add helper for tests

### DIFF
--- a/src/test_request.erl
+++ b/src/test_request.erl
@@ -13,7 +13,9 @@
 -module(test_request).
 
 -export([get/1, get/2, get/3]).
+-export([post/3]).
 -export([put/2, put/3]).
+-export([delete/1]).
 -export([options/1, options/2, options/3]).
 -export([request/3, request/4]).
 
@@ -25,6 +27,8 @@ get(Url, Headers) ->
 get(Url, Headers, Opts) ->
     request(get, Url, Headers, [], Opts).
 
+post(Url, Headers, Body) ->
+    request(post, Url, Headers, Body).
 
 put(Url, Body) ->
     request(put, Url, [], Body).
@@ -32,6 +36,8 @@ put(Url, Body) ->
 put(Url, Headers, Body) ->
     request(put, Url, Headers, Body).
 
+delete(Url) ->
+    request(delete, Url, []).
 
 options(Url) ->
     request(options, Url, []).

--- a/src/test_util.erl
+++ b/src/test_util.erl
@@ -20,6 +20,7 @@
 -export([request/3, request/4]).
 -export([start_couch/0, start_couch/1, stop_couch/0, stop_couch/1]).
 -export([start_config/1, stop_config/1]).
+-export([start_applications/1]).
 
 
 srcdir() ->


### PR DESCRIPTION
In order to make them reusable in the chhtpd integration-tests.
Additionally adding a post and delete helper.

COUCHDB-2462
