### PR TITLE
Refactor couch_httpd_auth's AuthModule construct

### DIFF
--- a/src/couch_httpd_auth.erl
+++ b/src/couch_httpd_auth.erl
@@ -73,17 +73,18 @@ default_authentication_handler(Req) ->
 default_authentication_handler(Req, AuthModule) ->
     case basic_name_pw(Req) of
     {User, Pass} ->
-        case AuthModule:get_user_creds(User) of
+        case AuthModule:get_user_creds(Req, User) of
             nil ->
                 throw({unauthorized, <<"Name or password is incorrect.">>});
-            UserProps ->
+            {ok, UserProps, AuthCtx} ->
                 reject_if_totp(UserProps),
                 UserName = ?l2b(User),
                 Password = ?l2b(Pass),
                 case authenticate(Password, UserProps) of
                     true ->
-                        UserProps2 = maybe_upgrade_password_hash(UserName, Password, UserProps,
-								 AuthModule),
+                        UserProps2 = maybe_upgrade_password_hash(
+                            Req, UserName, Password, UserProps,
+                            AuthModule, AuthCtx),
                         Req#httpd{user_ctx=#user_ctx{
                             name=UserName,
                             roles=couch_util:get_value(<<"roles">>, UserProps2, [])
@@ -195,9 +196,9 @@ cookie_authentication_handler(#httpd{mochi_req=MochiReq}=Req, AuthModule) ->
             Req;
         SecretStr ->
             Secret = ?l2b(SecretStr),
-            case AuthModule:get_user_creds(User) of
+            case AuthModule:get_user_creds(Req, User) of
             nil -> Req;
-            UserProps ->
+            {ok, UserProps, _AuthCtx} ->
                 UserSalt = couch_util:get_value(<<"salt">>, UserProps, <<"">>),
                 FullSecret = <<Secret/binary, UserSalt/binary>>,
                 ExpectedHash = crypto:sha_mac(FullSecret, User ++ ":" ++ TimeStr),
@@ -284,14 +285,15 @@ handle_session_req(#httpd{method='POST', mochi_req=MochiReq}=Req, AuthModule) ->
     UserName = ?l2b(couch_util:get_value("name", Form, "")),
     Password = ?l2b(couch_util:get_value("password", Form, "")),
     couch_log:debug("Attempt Login: ~s",[UserName]),
-    UserProps = case AuthModule:get_user_creds(UserName) of
-        nil -> [];
+    {ok, UserProps, AuthCtx} = case AuthModule:get_user_creds(Req, UserName) of
+        nil -> {ok, [], nil};
         Result -> Result
     end,
     case authenticate(Password, UserProps) of
         true ->
             verify_totp(UserProps, Form),
-            UserProps2 = maybe_upgrade_password_hash(UserName, Password, UserProps, AuthModule),
+            UserProps2 = maybe_upgrade_password_hash(
+                Req, UserName, Password, UserProps, AuthModule, AuthCtx),
             % setup the session cookie
             Secret = ?l2b(ensure_cookie_auth_secret()),
             UserSalt = couch_util:get_value(<<"salt">>, UserProps2),
@@ -363,18 +365,17 @@ maybe_value(_Key, undefined, _Fun) -> [];
 maybe_value(Key, Else, Fun) ->
     [{Key, Fun(Else)}].
 
-maybe_upgrade_password_hash(UserName, Password, UserProps, AuthModule) ->
+maybe_upgrade_password_hash(Req, UserName, Password, UserProps,
+        AuthModule, AuthCtx) ->
     IsAdmin = lists:member(<<"_admin">>, couch_util:get_value(<<"roles">>, UserProps, [])),
     case {IsAdmin, couch_util:get_value(<<"password_scheme">>, UserProps, <<"simple">>)} of
     {false, <<"simple">>} ->
-        DbName = ?l2b(config:get("couch_httpd_auth", "authentication_db", "_users")),
-        couch_util:with_db(DbName, fun(UserDb) ->
-            UserProps2 = proplists:delete(<<"password_sha">>, UserProps),
-            UserProps3 = [{<<"password">>, Password} | UserProps2],
-            NewUserDoc = couch_doc:from_json_obj({UserProps3}),
-            {ok, _NewRev} = couch_db:update_doc(UserDb, NewUserDoc, []),
-            AuthModule:get_user_creds(UserName)
-        end);
+        UserProps2 = proplists:delete(<<"password_sha">>, UserProps),
+        UserProps3 = [{<<"password">>, Password} | UserProps2],
+        NewUserDoc = couch_doc:from_json_obj({UserProps3}),
+        ok = AuthModule:update_user_creds(Req, NewUserDoc, AuthCtx),
+        {ok, NewUserProps, _} = AuthModule:get_user_creds(Req, UserName),
+        NewUserProps;
     _ ->
         UserProps
     end.

--- a/src/couch_httpd_auth.erl
+++ b/src/couch_httpd_auth.erl
@@ -21,6 +21,11 @@
 -export([cookie_auth_header/2]).
 -export([handle_session_req/1, handle_session_req/2]).
 
+-export([authenticate/2, verify_totp/2, maybe_upgrade_password_hash/6]).
+-export([ensure_cookie_auth_secret/0, make_cookie_time/0]).
+-export([cookie_auth_cookie/4, cookie_scheme/1]).
+-export([auth_name/1, maybe_value/3]).
+
 -import(couch_httpd, [header_value/2, send_json/2,send_json/4, send_method_not_allowed/2]).
 
 -compile({no_auto_import,[integer_to_binary/1]}).

--- a/src/couch_httpd_oauth.erl
+++ b/src/couch_httpd_oauth.erl
@@ -78,7 +78,7 @@ set_user_ctx(Req, Name) ->
             couch_log:debug("OAuth handler: user `~p` credentials not found",
                             [Name]),
             Req;
-        User ->
+        {ok, User, _AuthCtx} ->
             Roles = couch_util:get_value(<<"roles">>, User, []),
             Req#httpd{user_ctx=#user_ctx{name=Name, roles=Roles}}
     end.


### PR DESCRIPTION
We were missing the change necessary to upgrade user documents with the
move to pbkdf2 in a cluster. This also adds the ability for an
AuthModule to return a context that will be used when updating user
credentials.

COUCHDB-2491
