### PR TITLE
Add IS_OLD_RECORD macro

### DIFF
--- a/include/couch_db.hrl
+++ b/include/couch_db.hrl
@@ -23,6 +23,8 @@
 -define(JSON_ENCODE(V), couch_util:json_encode(V)).
 -define(JSON_DECODE(V), couch_util:json_decode(V)).
 
+-define(IS_OLD_RECORD(V, R), (tuple_size(V) /= tuple_size(R))).
+
 -define(b2l(V), binary_to_list(V)).
 -define(l2b(V), list_to_binary(V)).
 -define(i2b(V), couch_util:integer_to_boolean(V)).


### PR DESCRIPTION
This can be used in guards to detect if a state variable needs to be
upgraded. An example of it's use might be:

```
handle_call(Msg, From, St) when ?IS_OLD_RECORD(St, #st{}) ->
    handle_call(Msg, From, upgrade_state(St));
```

This is useful for upgrading any of our various gen behaviors that
aren't properly supervised.

COUCHDB-2511
