### PR TITLE
Modify init_delete_dir to be async

### DIFF
--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -260,10 +260,13 @@ init_delete_dir(RootDir) ->
     % note: ensure_dir requires an actual filename companent, which is the
     % reason for "foo".
     filelib:ensure_dir(filename:join(Dir,"foo")),
-    filelib:fold_files(Dir, ".*", true,
-        fun(Filename, _) ->
-            ok = file:delete(Filename)
-        end, ok).
+    spawn(fun() ->
+        filelib:fold_files(Dir, ".*", true,
+            fun(Filename, _) ->
+                ok = file:delete(Filename)
+            end, ok)
+    end),
+    ok.
 
 
 read_header(Fd) ->


### PR DESCRIPTION
In the case when .delete directory contains lots of files.
The deletion of the directory leads to timeout in the supervisor.
Which in it's turn kills the node.
So we rename original directory so couchdb cannot find it.
Then we remove files from renamed directory asynchronously.

COUCHDB-2524