### PR TITLE
Add a configurable timeout for get_proc calls

### DIFF
--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -342,9 +342,12 @@ proc_set_timeout(Proc, Timeout) ->
     {Mod, Func} = Proc#proc.set_timeout_fun,
     apply(Mod, Func, [Proc#proc.pid, Timeout]).
 
+get_os_process_timeout() ->
+    list_to_integer(config:get("couchdb", "os_process_timeout", "5000")).
+
 get_ddoc_process(#doc{} = DDoc, DDocKey) ->
     % remove this case statement
-    case gen_server:call(couch_proc_manager, {get_proc, DDoc, DDocKey}, infinity) of
+    case gen_server:call(couch_proc_manager, {get_proc, DDoc, DDocKey}, get_os_process_timeout()) of
     {ok, Proc, {QueryConfig}} ->
         % process knows the ddoc
         case (catch proc_prompt(Proc, [<<"reset">>, {QueryConfig}])) of
@@ -360,7 +363,7 @@ get_ddoc_process(#doc{} = DDoc, DDocKey) ->
     end.
 
 get_os_process(Lang) ->
-    case gen_server:call(couch_proc_manager, {get_proc, Lang}, infinity) of
+    case gen_server:call(couch_proc_manager, {get_proc, Lang}, get_os_process_timeout()) of
     {ok, Proc, {QueryConfig}} ->
         case (catch proc_prompt(Proc, [<<"reset">>, {QueryConfig}])) of
         true ->


### PR DESCRIPTION
Previously the gen_server calls to couch_proc_manager/get_proc
used a timeout of infinity. There are multiple places in the
couch_proc_manager code path where that process can die without
replying. With an infinity timeout the couch_query_server process
would then hang around forever.

This commit makes the gen_server call to get_proc use a configurable
timeout, set by the couchdb/get_proc_timeout config variable. It
defaults to 60000ms.

Closes:

  COUCHDB-2425
  COUCHDB-2426