### PR TITLE
Define ADMIN_USER and ADMIN_CTX macros

### DIFF
--- a/include/couch_db.hrl
+++ b/include/couch_db.hrl
@@ -37,6 +37,10 @@
 
 -define(DEFAULT_ATTACHMENT_CONTENT_TYPE, <<"application/octet-stream">>).
 
+-define(ADMIN_USER, #user_ctx{roles=[<<"_admin">>]}).
+-define(ADMIN_CTX, {user_ctx, ?ADMIN_USER}).
+
+
 -type branch() :: {Key::term(), Value::term(), Tree::term()}.
 -type path() :: {Start::pos_integer(), branch()}.
 

--- a/include/couch_eunit.hrl
+++ b/include/couch_eunit.hrl
@@ -12,9 +12,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(ADMIN_ROLE, #user_ctx{roles=[<<"_admin">>]}).
--define(ADMIN_USER, {user_ctx, ?ADMIN_ROLE}).
-
 -define(BUILDDIR,
     fun() ->
         case os:getenv("BUILDDIR") of

--- a/src/couch_auth_cache.erl
+++ b/src/couch_auth_cache.erl
@@ -432,7 +432,7 @@ get_user_props_from_db(UserName) ->
     ).
 
 ensure_users_db_exists(DbName, Options) ->
-    Options1 = [{user_ctx, #user_ctx{roles=[<<"_admin">>]}}, nologifmissing | Options],
+    Options1 = [?ADMIN_CTX, nologifmissing | Options],
     case couch_db:open(DbName, Options1) of
     {ok, Db} ->
         ensure_auth_ddoc_exists(Db, <<"_design/_auth">>),

--- a/src/couch_compaction_daemon.erl
+++ b/src/couch_compaction_daemon.erl
@@ -143,7 +143,7 @@ compact_loop(Parent) ->
 
 
 maybe_compact_db(DbName, Config) ->
-    case (catch couch_db:open_int(DbName, [{user_ctx, #user_ctx{roles=[<<"_admin">>]}}])) of
+    case (catch couch_db:open_int(DbName, [?ADMIN_CTX])) of
     {ok, Db} ->
         DDocNames = db_ddoc_names(Db),
         case can_db_compact(Config, Db) of

--- a/src/couch_db_updater.erl
+++ b/src/couch_db_updater.erl
@@ -614,7 +614,7 @@ refresh_validate_doc_funs(#db{name = <<"shards/", _/binary>> = Name} = Db) ->
     spawn(fabric, reset_validation_funs, [mem3:dbname(Name)]),
     Db#db{validate_doc_funs = undefined};
 refresh_validate_doc_funs(Db0) ->
-    Db = Db0#db{user_ctx = #user_ctx{roles=[<<"_admin">>]}},
+    Db = Db0#db{user_ctx=?ADMIN_USER},
     {ok, DesignDocs} = couch_db:get_design_docs(Db),
     ProcessDocFuns = lists:flatmap(
         fun(DesignDocInfo) ->

--- a/src/couch_httpd_auth.erl
+++ b/src/couch_httpd_auth.erl
@@ -48,7 +48,7 @@ special_test_authentication_handler(Req) ->
     _ ->
         % No X-Couch-Test-Auth credentials sent, give admin access so the
         % previous authentication can be restored after the test
-        Req#httpd{user_ctx=#user_ctx{roles=[<<"_admin">>]}}
+        Req#httpd{user_ctx=?ADMIN_USER}
     end.
 
 basic_name_pw(Req) ->
@@ -107,13 +107,13 @@ default_authentication_handler(Req, AuthModule) ->
                 "true" -> Req;
                 % If no admins, and no user required, then everyone is admin!
                 % Yay, admin party!
-                _ -> Req#httpd{user_ctx=#user_ctx{roles=[<<"_admin">>]}}
+                _ -> Req#httpd{user_ctx=?ADMIN_USER}
             end
         end
     end.
 
 null_authentication_handler(Req) ->
-    Req#httpd{user_ctx=#user_ctx{roles=[<<"_admin">>]}}.
+    Req#httpd{user_ctx=?ADMIN_USER}.
 
 %% @doc proxy auth handler.
 %

--- a/src/couch_httpd_oauth.erl
+++ b/src/couch_httpd_oauth.erl
@@ -344,8 +344,7 @@ use_auth_db() ->
 
 open_auth_db() ->
     DbName = ?l2b(config:get("couch_httpd_auth", "authentication_db")),
-    DbOptions = [{user_ctx, #user_ctx{roles = [<<"_admin">>]}}],
-    {ok, AuthDb} = couch_db:open_int(DbName, DbOptions),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     AuthDb.
 
 

--- a/src/couch_util.erl
+++ b/src/couch_util.erl
@@ -445,7 +445,7 @@ encode_doc_id(Id) ->
 with_db(Db, Fun) when is_record(Db, db) ->
     Fun(Db);
 with_db(DbName, Fun) ->
-    case couch_db:open_int(DbName, [{user_ctx, #user_ctx{roles=[<<"_admin">>]}}]) of
+    case couch_db:open_int(DbName, [?ADMIN_CTX]) of
         {ok, Db} ->
             try
                 Fun(Db)

--- a/test/couch_auth_cache_tests.erl
+++ b/test/couch_auth_cache_tests.erl
@@ -28,7 +28,7 @@ setup() ->
     DbName.
 
 teardown(DbName) ->
-    ok = couch_server:delete(DbName, [?ADMIN_USER]),
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
 
@@ -170,7 +170,7 @@ update_user_doc(DbName, UserName, Password, Rev) ->
             _ ->   [{<<"_rev">>, Rev}]
          end
     }),
-    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_USER]),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     {ok, NewRev} = couch_db:update_doc(AuthDb, Doc, []),
     ok = couch_db:close(AuthDb),
     {ok, couch_doc:rev_to_str(NewRev)}.
@@ -179,14 +179,14 @@ hash_password(Password) ->
     ?l2b(couch_util:to_hex(crypto:sha(iolist_to_binary([Password, ?SALT])))).
 
 shutdown_db(DbName) ->
-    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_USER]),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(AuthDb),
     couch_util:shutdown_sync(AuthDb#db.main_pid),
     ok = timer:sleep(1000).
 
 get_doc_rev(DbName, UserName) ->
     DocId = iolist_to_binary([<<"org.couchdb.user:">>, UserName]),
-    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_USER]),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     UpdateRev =
     case couch_db:open_doc(AuthDb, DocId, []) of
     {ok, Doc} ->
@@ -200,7 +200,7 @@ get_doc_rev(DbName, UserName) ->
 
 get_user_doc_password_sha(DbName, UserName) ->
     DocId = iolist_to_binary([<<"org.couchdb.user:">>, UserName]),
-    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_USER]),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     {ok, Doc} = couch_db:open_doc(AuthDb, DocId, []),
     ok = couch_db:close(AuthDb),
     {Props} = couch_doc:to_json_obj(Doc, []),
@@ -208,7 +208,7 @@ get_user_doc_password_sha(DbName, UserName) ->
 
 delete_user_doc(DbName, UserName) ->
     DocId = iolist_to_binary([<<"org.couchdb.user:">>, UserName]),
-    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_USER]),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     {ok, Doc} = couch_db:open_doc(AuthDb, DocId, []),
     {Props} = couch_doc:to_json_obj(Doc, []),
     DeletedDoc = couch_doc:from_json_obj({[
@@ -220,7 +220,7 @@ delete_user_doc(DbName, UserName) ->
     ok = couch_db:close(AuthDb).
 
 full_commit(DbName) ->
-    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_USER]),
+    {ok, AuthDb} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     {ok, _} = couch_db:ensure_full_commit(AuthDb),
     ok = couch_db:close(AuthDb).
 

--- a/test/couch_changes_tests.erl
+++ b/test/couch_changes_tests.erl
@@ -329,7 +329,7 @@ should_emit_only_design_documents({DbName, Revs}) ->
 
             stop_consumer(Consumer),
 
-            {ok, Db2} = couch_db:open_int(DbName, [?ADMIN_USER]),
+            {ok, Db2} = couch_db:open_int(DbName, [?ADMIN_CTX]),
             {ok, _} = save_doc(Db2, {[{<<"_id">>, <<"_design/foo">>},
                                       {<<"_rev">>, element(8, Revs)},
                                       {<<"_deleted">>, true}]}),
@@ -593,9 +593,9 @@ stop_loop(Parent, Acc) ->
     end.
 
 create_db(DbName) ->
-    couch_db:create(DbName, [?ADMIN_USER, overwrite]).
+    couch_db:create(DbName, [?ADMIN_CTX, overwrite]).
 
 delete_db(DbName) ->
-    ok = couch_server:delete(DbName, [?ADMIN_USER]).
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]).
 
 -endif.

--- a/test/couchdb_compaction_daemon.erl
+++ b/test/couchdb_compaction_daemon.erl
@@ -30,7 +30,7 @@ start() ->
 
 setup() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     create_design_doc(Db),
     ok = couch_db:close(Db),
     DbName.
@@ -42,7 +42,7 @@ teardown(DbName) ->
             ok = config:delete("compactions", Key, false)
         end,
         Configs),
-    couch_server:delete(DbName, [?ADMIN_USER]),
+    couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
 

--- a/test/couchdb_cors_tests.erl
+++ b/test/couchdb_cors_tests.erl
@@ -29,7 +29,7 @@ start() ->
 
 setup() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     couch_db:close(Db),
 
     config:set("cors", "credentials", "false", false),
@@ -53,7 +53,7 @@ setup({Mod, VHost}) ->
     {Host, DbName, Url, DefaultHeaders}.
 
 teardown(DbName) when is_list(DbName) ->
-    ok = couch_server:delete(?l2b(DbName), [?ADMIN_USER]),
+    ok = couch_server:delete(?l2b(DbName), [?ADMIN_CTX]),
     ok;
 teardown({_, DbName}) ->
     teardown(DbName).

--- a/test/couchdb_file_compression_tests.erl
+++ b/test/couchdb_file_compression_tests.erl
@@ -25,7 +25,7 @@
 setup() ->
     config:set("couchdb", "file_compression", "none", false),
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = populate_db(Db, ?DOCS_COUNT),
     DDoc = couch_doc:from_json_obj({[
         {<<"_id">>, ?DDOC_ID},
@@ -43,7 +43,7 @@ setup() ->
     DbName.
 
 teardown(DbName) ->
-    ok = couch_server:delete(DbName, [?ADMIN_USER]),
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
 

--- a/test/couchdb_location_header_tests.erl
+++ b/test/couchdb_location_header_tests.erl
@@ -20,7 +20,7 @@
 
 setup() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     couch_db:close(Db),
 
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
@@ -29,7 +29,7 @@ setup() ->
     {Host, ?b2l(DbName)}.
 
 teardown({_, DbName}) ->
-    ok = couch_server:delete(?l2b(DbName), [?ADMIN_USER]),
+    ok = couch_server:delete(?l2b(DbName), [?ADMIN_CTX]),
     ok.
 
 

--- a/test/couchdb_update_conflicts_tests.erl
+++ b/test/couchdb_update_conflicts_tests.erl
@@ -30,7 +30,7 @@ start() ->
 
 setup() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER, overwrite]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX, overwrite]),
     Doc = couch_doc:from_json_obj({[{<<"_id">>, ?DOC_ID},
                                     {<<"value">>, 0}]}),
     {ok, Rev} = couch_db:update_doc(Db, Doc, []),

--- a/test/couchdb_vhosts_tests.erl
+++ b/test/couchdb_vhosts_tests.erl
@@ -23,7 +23,7 @@
 
 setup() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"doc1">>},
         {<<"value">>, 666}
@@ -55,7 +55,7 @@ setup() ->
 
 setup_oauth() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
 
     config:set("couch_httpd_auth", "authentication_db",
                      ?b2l(?tempdb()), false),
@@ -370,8 +370,8 @@ should_succeed_oauth({Url, _}) ->
             {<<"password_sha">>, <<"fe95df1ca59a9b567bdca5cbaf8412abd6e06121">>},
             {<<"salt">>, <<"4e170ffeb6f34daecfd814dfb4001a73">>}
         ]}),
-        {ok, AuthDb} = couch_db:open_int(?l2b(AuthDbName), [?ADMIN_USER]),
-        {ok, _} = couch_db:update_doc(AuthDb, JoeDoc, [?ADMIN_USER]),
+        {ok, AuthDb} = couch_db:open_int(?l2b(AuthDbName), [?ADMIN_CTX]),
+        {ok, _} = couch_db:update_doc(AuthDb, JoeDoc, [?ADMIN_CTX]),
 
         Host = "oauth-example.com",
         Consumer = {"consec1", "foo", hmac_sha1},
@@ -404,8 +404,8 @@ should_fail_oauth_with_wrong_credentials({Url, _}) ->
             {<<"password_sha">>, <<"fe95df1ca59a9b567bdca5cbaf8412abd6e06121">>},
             {<<"salt">>, <<"4e170ffeb6f34daecfd814dfb4001a73">>}
         ]}),
-        {ok, AuthDb} = couch_db:open_int(?l2b(AuthDbName), [?ADMIN_USER]),
-        {ok, _} = couch_db:update_doc(AuthDb, JoeDoc, [?ADMIN_USER]),
+        {ok, AuthDb} = couch_db:open_int(?l2b(AuthDbName), [?ADMIN_CTX]),
+        {ok, _} = couch_db:update_doc(AuthDb, JoeDoc, [?ADMIN_CTX]),
 
         Host = "oauth-example.com",
         Consumer = {"consec1", "bad_secret", hmac_sha1},

--- a/test/couchdb_views_tests.erl
+++ b/test/couchdb_views_tests.erl
@@ -24,7 +24,7 @@
 
 setup() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     FooRev = create_design_doc(DbName, <<"_design/foo">>, <<"bar">>),
     query_view(DbName, "foo", "bar"),
@@ -34,7 +34,7 @@ setup() ->
 
 setup_with_docs() ->
     DbName = ?tempdb(),
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     create_docs(DbName),
     create_design_doc(DbName, <<"_design/foo">>, <<"bar">>),
@@ -43,7 +43,7 @@ setup_with_docs() ->
 teardown({DbName, _}) ->
     teardown(DbName);
 teardown(DbName) when is_binary(DbName) ->
-    couch_server:delete(DbName, [?ADMIN_USER]),
+    couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
 
@@ -277,7 +277,7 @@ couchdb_1309(DbName) ->
         end,
 
         MonRef1 = erlang:monitor(process, NewIndexerPid),
-        ok = couch_server:delete(DbName, [?ADMIN_USER]),
+        ok = couch_server:delete(DbName, [?ADMIN_CTX]),
         receive
             {'DOWN', MonRef1, _, _, _} ->
                 ok
@@ -294,7 +294,7 @@ couchdb_1283() ->
         ok = config:set("couchdb", "max_dbs_open", "3", false),
         ok = config:set("couchdb", "delayed_commits", "false", false),
 
-        {ok, MDb1} = couch_db:create(?tempdb(), [?ADMIN_USER]),
+        {ok, MDb1} = couch_db:create(?tempdb(), [?ADMIN_CTX]),
         DDoc = couch_doc:from_json_obj({[
             {<<"_id">>, <<"_design/foo">>},
             {<<"language">>, <<"javascript">>},
@@ -321,11 +321,11 @@ couchdb_1283() ->
         query_view(MDb1#db.name, "foo", "foo"),
         ok = couch_db:close(MDb1),
 
-        {ok, Db1} = couch_db:create(?tempdb(), [?ADMIN_USER]),
+        {ok, Db1} = couch_db:create(?tempdb(), [?ADMIN_CTX]),
         ok = couch_db:close(Db1),
-        {ok, Db2} = couch_db:create(?tempdb(), [?ADMIN_USER]),
+        {ok, Db2} = couch_db:create(?tempdb(), [?ADMIN_CTX]),
         ok = couch_db:close(Db2),
-        {ok, Db3} = couch_db:create(?tempdb(), [?ADMIN_USER]),
+        {ok, Db3} = couch_db:create(?tempdb(), [?ADMIN_CTX]),
         ok = couch_db:close(Db3),
 
         Writer1 = spawn_writer(Db1#db.name),
@@ -373,7 +373,7 @@ couchdb_1283() ->
 create_doc(DbName, DocId) when is_list(DocId) ->
     create_doc(DbName, ?l2b(DocId));
 create_doc(DbName, DocId) when is_binary(DocId) ->
-    {ok, Db} = couch_db:open(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     Doc666 = couch_doc:from_json_obj({[
         {<<"_id">>, DocId},
         {<<"value">>, 999}
@@ -383,7 +383,7 @@ create_doc(DbName, DocId) when is_binary(DocId) ->
     couch_db:close(Db).
 
 create_docs(DbName) ->
-    {ok, Db} = couch_db:open(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     Doc1 = couch_doc:from_json_obj({[
         {<<"_id">>, <<"doc1">>},
         {<<"value">>, 1}
@@ -418,7 +418,7 @@ populate_db(_Db, _, _) ->
     ok.
 
 create_design_doc(DbName, DDName, ViewName) ->
-    {ok, Db} = couch_db:open(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     DDoc = couch_doc:from_json_obj({[
         {<<"_id">>, DDName},
         {<<"language">>, <<"javascript">>},
@@ -434,8 +434,8 @@ create_design_doc(DbName, DDName, ViewName) ->
     Rev.
 
 update_design_doc(DbName, DDName, ViewName) ->
-    {ok, Db} = couch_db:open(DbName, [?ADMIN_USER]),
-    {ok, Doc} = couch_db:open_doc(Db, DDName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
+    {ok, Doc} = couch_db:open_doc(Db, DDName, [?ADMIN_CTX]),
     {Props} = couch_doc:to_json_obj(Doc, []),
     Rev = couch_util:get_value(<<"_rev">>, Props),
     DDoc = couch_doc:from_json_obj({[
@@ -448,13 +448,13 @@ update_design_doc(DbName, DDName, ViewName) ->
             ]}}
         ]}}
     ]}),
-    {ok, NewRev} = couch_db:update_doc(Db, DDoc, [?ADMIN_USER]),
+    {ok, NewRev} = couch_db:update_doc(Db, DDoc, [?ADMIN_CTX]),
     couch_db:ensure_full_commit(Db),
     couch_db:close(Db),
     NewRev.
 
 delete_design_doc(DbName, DDName, Rev) ->
-    {ok, Db} = couch_db:open(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     DDoc = couch_doc:from_json_obj({[
         {<<"_id">>, DDName},
         {<<"_rev">>, couch_doc:rev_to_str(Rev)},
@@ -489,7 +489,7 @@ check_rows_value(Rows, Value) ->
         end, Rows).
 
 view_cleanup(DbName) ->
-    {ok, Db} = couch_db:open(DbName, [?ADMIN_USER]),
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     couch_mrview:cleanup(Db),
     couch_db:close(Db).
 


### PR DESCRIPTION
We're repeating ourself too often with his macros.
This causes the following changes:
https://github.com/kxepal/couchdb-chttpd/compare/apache:master...define-adminctx
https://github.com/kxepal/couchdb-mem3/compare/apache:master...define-adminctx
https://github.com/kxepal/couchdb-couch-mrview/compare/apache:master...define-adminctx
https://github.com/kxepal/couchdb-couch-replicator/compare/apache:master...define-adminctx
https://github.com/kxepal/couchdb-fabric/compare/apache:master...define-adminctx
https://github.com/kxepal/couchdb-global-changes/compare/apache:master...define-adminctx
https://github.com/kxepal/couchdb-cassim/compare/apache:master...define-adminctx