### PR TITLE
add _changes?feed=stream sugar for continuous

### DIFF
--- a/src/couch_httpd_db.erl
+++ b/src/couch_httpd_db.erl
@@ -1131,6 +1131,9 @@ parse_doc_query(Req) ->
 parse_changes_query(Req, Db) ->
     ChangesArgs = lists:foldl(fun({Key, Value}, Args) ->
         case {string:to_lower(Key), Value} of
+        {"feed", "live"} ->
+            %% sugar for continuous
+            Args#changes_args{feed="continuous"};
         {"feed", _} ->
             Args#changes_args{feed=Value};
         {"descending", "true"} ->


### PR DESCRIPTION
allow `feed=stream` as sugar for `continuous` which is hard to
type.

PRs for the change:
https://github.com/apache/couchdb/pull/307
https://github.com/apache/couchdb-couch/pull/40
https://github.com/apache/couchdb-chttpd/pull/28

closes COUCHDB-2237