### PR TITLE
Include lager into list of extra apps when testing

### DIFF
--- a/src/test_util.erl
+++ b/src/test_util.erl
@@ -69,10 +69,9 @@ start_couch(ExtraApps) ->
 start_couch(IniFiles, ExtraApps) ->
     load_applications_with_stats(),
     ok = application:set_env(config, ini_files, IniFiles),
-    ok = lager:start(),
 
     Apps = start_applications(
-        [inets, ibrowse, ssl, config, couch_event, couch]
+        [goldrush, lager, inets, ibrowse, ssl, config, couch_event, couch]
         ++ ExtraApps),
 
     #test_context{started = Apps}.


### PR DESCRIPTION
Starting lager as `lager:start` is an issue since dependencies
started by lager are not included in a list of started applications
so we don't stop them after we are done with current test.

This commit uses test_util:start_applications so all deps of lager are
included into #test_context{}

COUCHDB-2688