### PR TITLE
perf: increase performance of http handlers

### DIFF
--- a/src/couch_httpd.erl
+++ b/src/couch_httpd.erl
@@ -611,12 +611,17 @@ log_request(#httpd{mochi_req=MochiReq,peer=Peer}=Req, Code) ->
         true ->
             ok;
         _ ->
-            couch_log:notice("~s - - ~s ~s ~B", [
+            Method = MochiReq:get(method),
+            Msg = [
                 Peer,
-                MochiReq:get(method),
+                " - - ",
+                atom_to_list(Method),
+                " ",
                 MochiReq:get(raw_path),
-                Code
-            ]),
+                " ",
+                integer_to_list(Code)
+            ],
+            couch_log:notice(lists:flatten(Msg)),
             gen_event:notify(couch_plugin, {log_request, Req, Code})
     end.
 


### PR DESCRIPTION
we are avoiding lagers formatting here which happens before it
asynchronously dispatches the event.

for a /get on a document this increases perfomance ~4% and should
apply to all http requests.

PRs:
https://github.com/apache/couchdb-couch-log/pull/2
https://github.com/apache/couchdb-couch/pull/57

Benchmarking and profiling
===

Sadly GitHub does not allow svg uploads

Before
---
![flame--second--unpatched](https://cloud.githubusercontent.com/assets/298166/7948941/0c55302c-0989-11e5-8266-8a6fc574f4c4.png)

After
---
![flame--second--patched](https://cloud.githubusercontent.com/assets/298166/7948937/0751fbb4-0989-11e5-998c-cc34b723ee0e.png)

Benchmark data
---
http://robert-kowalski.de/assets/data/2015-06-01-erlang-perf-2/results-siege.txt
