### PR TITLE
Introduce couch_db:normalize_dbname

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -33,6 +33,7 @@
 -export([load_validation_funs/1]).
 -export([check_md5/2, with_stream/3]).
 -export([monitored_by/1]).
+-export([normalize_dbname/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -1469,3 +1470,8 @@ select_gt(V1, _V2) -> V1.
 
 select_lt(V1, V2) when V1 > V2 -> V2;
 select_lt(V1, _V2) -> V1.
+
+normalize_dbname(<<"shards/", _/binary>> = Path) ->
+    lists:last(binary:split(mem3:dbname(Path), <<"/">>, [global]));
+normalize_dbname(DbName) ->
+    DbName.

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -140,7 +140,7 @@ maybe_add_sys_db_callbacks(DbName, Options) ->
     end.
 
 path_ends_with(Path, Suffix) ->
-    Suffix == lists:last(binary:split(mem3:dbname(Path), <<"/">>, [global])).
+    Suffix == couch_db:normalize_dbname(Path).
 
 check_dbname(#server{dbname_regexp=RegExp}, DbName) ->
     case re:run(DbName, RegExp, [{capture, none}]) of


### PR DESCRIPTION
Move duplicated logic into couch_db:normalize_dbname. We could use this
helper function anywhere we need to extract dbname from shard path.

COUCHDB-2715

We would need this PR for COUCHDB-2635