### PR TITLE
COUCHDB-2722 Keys from rewrited query params should be blank when not specified in the URI

### DIFF
--- a/src/couch_httpd_rewrite.erl
+++ b/src/couch_httpd_rewrite.erl
@@ -271,8 +271,11 @@ replace_var(Value, _Bindings, _Formats) when is_binary(Value) ->
     Value;
 replace_var(Value, Bindings, Formats) when is_list(Value) ->
     lists:reverse(lists:foldl(fun
-                (<<":", Var/binary>>=Value1, Acc) ->
-                    [get_var(Var, Bindings, Value1, Formats)|Acc];
+                (<<":", Var/binary>>, Acc) ->
+                    case get_var(Var, Bindings, undefined, Formats) of 
+                         undefined -> [''|Acc] ;
+                         DefinedValue -> [DefinedValue|Acc]
+                    end;
                 (Value1, Acc) ->
                     [Value1|Acc]
             end, [], Value));


### PR DESCRIPTION
## Bug Fix
### COUCHDB-2722 

The keys from the rewrited query params of a view should be blank when not specified in the URL.

*Please see the following JIRA link for more details...*

### JIRA
https://issues.apache.org/jira/browse/COUCHDB-2722

### Related Pull Requests

- Fix against __couchdb-chttpd__ :
- End-to-end tests against __couchdb__ : 