### PR TITLE
Configurable password scheme

### DIFF
--- a/src/couch_httpd_auth.erl
+++ b/src/couch_httpd_auth.erl
@@ -372,9 +372,11 @@ maybe_value(Key, Else, Fun) ->
 
 maybe_upgrade_password_hash(Req, UserName, Password, UserProps,
         AuthModule, AuthCtx) ->
+    Upgrade = config:get_boolean("couch_httpd_auth", "upgrade_password_on_auth", true),
     IsAdmin = lists:member(<<"_admin">>, couch_util:get_value(<<"roles">>, UserProps, [])),
-    case {IsAdmin, couch_util:get_value(<<"password_scheme">>, UserProps, <<"simple">>)} of
-    {false, <<"simple">>} ->
+    case {IsAdmin, Upgrade,
+         couch_util:get_value(<<"password_scheme">>, UserProps, <<"simple">>)} of
+    {false, true, <<"simple">>} ->
         UserProps2 = proplists:delete(<<"password_sha">>, UserProps),
         UserProps3 = [{<<"password">>, Password} | UserProps2],
         NewUserDoc = couch_doc:from_json_obj({UserProps3}),

--- a/src/couch_passwords.erl
+++ b/src/couch_passwords.erl
@@ -30,6 +30,15 @@ simple(Password, Salt) when is_binary(Password), is_binary(Salt) ->
 hash_admin_password(ClearPassword) when is_list(ClearPassword) ->
     hash_admin_password(?l2b(ClearPassword));
 hash_admin_password(ClearPassword) when is_binary(ClearPassword) ->
+    %% Support both schemes to smooth migration from legacy scheme
+    Scheme = config:get("couch_httpd_auth", "password_scheme", "pbkdf2"),
+    hash_admin_password(Scheme, ClearPassword).
+
+hash_admin_password("simple", ClearPassword) -> % deprecated
+    Salt = couch_uuids:random(),
+    Hash = crypto:sha(<<ClearPassword/binary, Salt/binary>>),
+    ?l2b("-hashed-" ++ couch_util:to_hex(Hash) ++ "," ++ ?b2l(Salt));
+hash_admin_password("pbkdf2", ClearPassword) ->
     Iterations = config:get("couch_httpd_auth", "iterations", "10000"),
     Salt = couch_uuids:random(),
     DerivedKey = couch_passwords:pbkdf2(couch_util:to_binary(ClearPassword),


### PR DESCRIPTION
This gives the administrator control over which algorithm is used to
hash passwords and a separate control over whether this happens on
successful authentication or only at password change time.

closes COUCHDB-2725