### PR TITLE
Remove compression's optimization

### DIFF
--- a/src/couch_compress.erl
+++ b/src/couch_compress.erl
@@ -43,6 +43,8 @@ compress(<<?SNAPPY_PREFIX, _/binary>> = Bin, snappy) ->
     Bin;
 compress(<<?SNAPPY_PREFIX, _/binary>> = Bin, Method) ->
     compress(decompress(Bin), Method);
+compress(<<?COMPRESSED_TERM_PREFIX, _/binary>> = Bin, {deflate, _Level}) ->
+    Bin;
 compress(<<?TERM_PREFIX, _/binary>> = Bin, Method) ->
     compress(decompress(Bin), Method);
 compress(Term, none) ->
@@ -53,12 +55,7 @@ compress(Term, snappy) ->
     Bin = ?term_to_bin(Term),
     try
         {ok, CompressedBin} = snappy:compress(Bin),
-        case byte_size(CompressedBin) < byte_size(Bin) of
-        true ->
-            <<?SNAPPY_PREFIX, CompressedBin/binary>>;
-        false ->
-            Bin
-        end
+        <<?SNAPPY_PREFIX, CompressedBin/binary>>
     catch exit:snappy_nif_not_loaded ->
         Bin
     end.


### PR DESCRIPTION
When a file compression set to snappy, couch is doing an additional
optimization step by also compressing the term with deflate,
comparing the sizes of the result binary and choosing the smaller one.
This leads to a situation when for snappy compresed database the
'winning' deflate compressed term got decompressed and compressed
back into deflate on each document's write.

This patch removes this compression's optimization.

[Basic test](http://nbviewer.ipython.org/gist/eiri/79d91a797af9c6a6ff6d)
demonstrate that the gained with it disk space is not significant
enough to justify empty CPU cycles.

This closes COUCHDB-2726