### PR TITLE
Support Windows compilation for couch_ejson_compare

### DIFF
--- a/priv/couch_ejson_compare/couch_ejson_compare.c
+++ b/priv/couch_ejson_compare/couch_ejson_compare.c
@@ -31,6 +31,12 @@
      !enif_is_tuple(env, t))
 #endif
 
+#ifdef _MSC_VER
+#define threadlocal __declspec(thread)
+#else
+#define threadlocal __thread
+#endif
+
 static ERL_NIF_TERM ATOM_TRUE;
 static ERL_NIF_TERM ATOM_FALSE;
 static ERL_NIF_TERM ATOM_NULL;
@@ -41,7 +47,7 @@ typedef struct {
     UCollator* coll;
 } ctx_t;
 
-static __thread UCollator* collator = NULL;
+static threadlocal UCollator* collator = NULL;
 static UCollator** collators = NULL;
 static int numCollators = 0;
 static int numSchedulers = 0;


### PR DESCRIPTION
MSVC uses __declspec(thread) rather than __thread, so created a macro for it.