### PR TITLE
Don't enable host validation by default

### DIFF
--- a/src/couch_httpd.erl
+++ b/src/couch_httpd.erl
@@ -360,7 +360,7 @@ handle_request_int(MochiReq, DefaultFun,
     {ok, Resp}.
 
 validate_host(#httpd{} = Req) ->
-    case config:get_boolean("httpd", "validate_host", true) of
+    case config:get_boolean("httpd", "validate_host", false) of
         true ->
             Host = hostname(Req),
             ValidHosts = valid_hosts(),
@@ -384,12 +384,8 @@ hostname(#httpd{} = Req) ->
     end.
 
 valid_hosts() ->
-    case config:get("httpd", "valid_hosts") of
-        undefined ->
-            ["localhost", "127.0.0.1", "[::1]", net_adm:localhost()];
-        List ->
-            re:split(List, ",", [{return, list}])
-    end.
+    List = config:get("httpd", "valid_hosts", ""),
+    re:split(List, ",", [{return, list}]).
 
 check_request_uri_length(Uri) ->
     check_request_uri_length(Uri, config:get("httpd", "max_uri_length")).


### PR DESCRIPTION
Revising original stance. Administrators can enable this feature if
they want, and supply the definitive list of allowed Host values.

When enabled, the default list of valid hosts is empty.

COUCHDB-2752