### PR TITLE
correct inverted test function name

### DIFF
--- a/test/couchdb_auth_tests.erl
+++ b/test/couchdb_auth_tests.erl
@@ -34,7 +34,7 @@ auth_test_() ->
                 foreach,
                 fun setup/0, fun teardown/1,
                 [
-                    fun should_not_return_username_on_post_to_session/1
+                    fun should_return_username_on_post_to_session/1
                 ]
             }
         }

--- a/test/couchdb_auth_tests.erl
+++ b/test/couchdb_auth_tests.erl
@@ -40,7 +40,7 @@ auth_test_() ->
         }
     }.
 
-should_not_return_username_on_post_to_session(Url) ->
+should_return_username_on_post_to_session(Url) ->
     ?_assertEqual(<<"rocko">>,
         begin
             ok = config:set("admins", "rocko", "artischocko", false),


### PR DESCRIPTION
Based on this [article](http://robert-kowalski.de/blog/lets-learn-erlang-and-fix-a-bug-on-a-couchdb-cluster/), the function is ensuring that a username is returned.  This change just removes the "not" from the test function name.