### PR TITLE
Return bad_request on view compilation error

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -604,7 +604,12 @@ validate_doc_update(Db, Doc, GetDiskDocFun) ->
 
 validate_ddoc(DbName, DDoc) ->
     try
-        couch_index_server:validate(DbName, couch_doc:with_ejson_body(DDoc))
+        case couch_index_server:validate(DbName, couch_doc:with_ejson_body(DDoc)) of
+            {compilation_error, Msg} ->
+                {bad_request, compilation_error, Msg};
+            Else ->
+                Else
+        end
     catch
         throw:{invalid_design_doc, Reason} ->
             {bad_request, invalid_design_doc, Reason};

--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -41,7 +41,7 @@ try_compile(Proc, FunctionType, FunctionName, FunctionSource) ->
     catch {compilation_error, E} ->
         Fmt = "Compilation of the ~s function in the '~s' view failed: ~s",
         Msg = io_lib:format(Fmt, [FunctionType, FunctionName, E]),
-        throw({compilation_error, Msg})
+        throw({bad_request, compilation_error, Msg})
     end.
 
 start_doc_map(Lang, Functions, Lib) ->

--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -41,7 +41,7 @@ try_compile(Proc, FunctionType, FunctionName, FunctionSource) ->
     catch {compilation_error, E} ->
         Fmt = "Compilation of the ~s function in the '~s' view failed: ~s",
         Msg = io_lib:format(Fmt, [FunctionType, FunctionName, E]),
-        throw({bad_request, compilation_error, Msg})
+        throw({compilation_error, Msg})
     end.
 
 start_doc_map(Lang, Functions, Lib) ->


### PR DESCRIPTION
A request adding a non-compiling view was previously generating
an HTTP 500 response. However, because the request is supplying an
invalid view an HTTP 400 bad request response would be appropriate
here. It would also make things clearer to the client that the
fault lies within the request rather than the server.

This commit updates the error returned on view compilation error
to a {bad_request, compilation_error, Msg}. This will be converted
into an HTTP 400 response by chttpd.

Closes COUCHDB-2772