### PR TITLE
Fix crashing filtered _changes request

### DIFF
--- a/src/couch_httpd_external.erl
+++ b/src/couch_httpd_external.erl
@@ -58,7 +58,8 @@ json_req_obj(#httpd{mochi_req=Req,
                method=Method,
                requested_path_parts=RequestedPath,
                path_parts=Path,
-               req_body=ReqBody
+               req_body=ReqBody,
+               peer=Peer
             }, Db, DocId) ->
     Body = case ReqBody of
         undefined ->
@@ -91,7 +92,7 @@ json_req_obj(#httpd{mochi_req=Req,
         {<<"query">>, json_query_keys(to_json_terms(Req:parse_qs()))},
         {<<"headers">>, to_json_terms(Hlist)},
         {<<"body">>, Body},
-        {<<"peer">>, ?l2b(Req:get(peer))},
+        {<<"peer">>, ?l2b(Peer)},
         {<<"form">>, to_json_terms(ParsedForm)},
         {<<"cookie">>, to_json_terms(Req:parse_cookie())},
         {<<"userCtx">>, couch_util:json_user_ctx(Db)},


### PR DESCRIPTION
A filtered call to _changes end-point prompts a node to
pull a peer from the received mochi request record.
This is crashing on the secondary nodes in a clustered
environment since the peer call made on a socket
that is not original for them.

The fix makes use of the fact that by the time of the request
the peer already got resolved on the coordinator node and
passed along as a part of #http record.

This closes the case COUCHDB-2785