### PR TITLE
check POST requests for valid json header

### DIFF
--- a/src/couch_changes.erl
+++ b/src/couch_changes.erl
@@ -310,6 +310,7 @@ get_view_qs(Req) ->
 get_doc_ids({json_req, {Props}}) ->
     check_docids(couch_util:get_value(<<"doc_ids">>, Props));
 get_doc_ids(#httpd{method='POST'}=Req) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
     {Props} = couch_httpd:json_body_obj(Req),
     check_docids(couch_util:get_value(<<"doc_ids">>, Props));
 get_doc_ids(#httpd{method='GET'}=Req) ->

--- a/src/couch_httpd_db.erl
+++ b/src/couch_httpd_db.erl
@@ -381,6 +381,7 @@ db_req(#httpd{path_parts=[_,<<"_purge">>]}=Req, _Db) ->
     send_method_not_allowed(Req, "POST");
 
 db_req(#httpd{method='POST',path_parts=[_,<<"_missing_revs">>]}=Req, Db) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
     {JsonDocIdRevs} = couch_httpd:json_body_obj(Req),
     JsonDocIdRevs2 = [{Id, [couch_doc:parse_rev(RevStr) || RevStr <- RevStrs]} || {Id, RevStrs} <- JsonDocIdRevs],
     {ok, Results} = couch_db:get_missing_revs(Db, JsonDocIdRevs2),
@@ -393,6 +394,7 @@ db_req(#httpd{path_parts=[_,<<"_missing_revs">>]}=Req, _Db) ->
     send_method_not_allowed(Req, "POST");
 
 db_req(#httpd{method='POST',path_parts=[_,<<"_revs_diff">>]}=Req, Db) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
     {JsonDocIdRevs} = couch_httpd:json_body_obj(Req),
     JsonDocIdRevs2 =
         [{Id, couch_doc:parse_revs(RevStrs)} || {Id, RevStrs} <- JsonDocIdRevs],

--- a/src/couch_httpd_misc_handlers.erl
+++ b/src/couch_httpd_misc_handlers.erl
@@ -185,6 +185,8 @@ handle_config_req(#httpd{method='GET', path_parts=[_, Section, Key]}=Req) ->
     end;
 % POST /_config/_reload - Flushes unpersisted config values from RAM
 handle_config_req(#httpd{method='POST', path_parts=[_, <<"_reload">>]}=Req) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
+    _ = couch_httpd:body(Req),
     ok = couch_httpd:verify_is_server_admin(Req),
     ok = config:reload(),
     send_json(Req, 200, {[{ok, true}]});


### PR DESCRIPTION
validate that all POST requests with json body must have also have valid
json header: {"Content-Type": "application/json"}
This ensures a basic protection against CSRF

JIRA: COUCHDB-2775