### PR TITLE
Inherit io_priority from the process creating the stream

### DIFF
--- a/src/couch_stream.erl
+++ b/src/couch_stream.erl
@@ -51,7 +51,7 @@ open(Fd) ->
     open(Fd, []).
 
 open(Fd, Options) ->
-    gen_server:start_link(couch_stream, {Fd, self(), Options}, []).
+    gen_server:start_link(couch_stream, {Fd, self(), erlang:get(io_priority), Options}, []).
 
 close(Pid) ->
     gen_server:call(Pid, close, infinity).
@@ -198,7 +198,8 @@ write(Pid, Bin) ->
     gen_server:call(Pid, {write, Bin}, infinity).
 
 
-init({Fd, OpenerPid, Options}) ->
+init({Fd, OpenerPid, OpenerPriority, Options}) ->
+    erlang:put(io_priority, OpenerPriority),
     {EncodingFun, EndEncodingFun} =
     case couch_util:get_value(encoding, Options, identity) of
     identity ->


### PR DESCRIPTION
`couch_stream` should be able to reuse the `io_priority` of whatever process creates it; it's then the creator's responsibility to decide what `io_priority` the stream should have.

Assigning streaming IO operations their own separately-tunable category of `io_priority` is an alternative to this change. The usefulness of that would depend on whether streaming IO in general has predictable load impacts that would be useful to observe and control for. Since `couch_stream` is only currently used by `couch_att`, though, giving attachment upload operations specifically an `io_priority` category might make more sense.

COUCHDB-2828
BugzID: 25815