### PR TITLE
Add revs limit for docs passed to filter functions

### DIFF
--- a/include/couch_db.hrl
+++ b/include/couch_db.hrl
@@ -229,3 +229,10 @@
     atts = []
 }).
 
+
+-type doc() :: #doc{}.
+-type ddoc() :: #doc{}.
+-type user_ctx() :: #user_ctx{}.
+-type sec_props() :: [tuple()].
+-type sec_obj() :: {sec_props()}.
+

--- a/src/couch_doc.erl
+++ b/src/couch_doc.erl
@@ -48,13 +48,20 @@ to_json_body(true, {Body}) ->
 to_json_body(false, {Body}) ->
     Body.
 
-to_json_revisions(Options, Start, RevIds) ->
-    case lists:member(revs, Options) of
-    false -> [];
-    true ->
+to_json_revisions(Options, Start, RevIds0) ->
+    RevIds = case proplists:get_value(revs, Options) of
+        true ->
+            RevIds0;
+        Num when is_integer(Num), Num > 0 ->
+            lists:sublist(RevIds0, Num);
+        _ ->
+           []
+    end,
+    if RevIds == [] -> []; true ->
         [{<<"_revisions">>, {[{<<"start">>, Start},
-                {<<"ids">>, [revid_to_str(R) ||R <- RevIds]}]}}]
+            {<<"ids">>, [revid_to_str(R) ||R <- RevIds]}]}}]
     end.
+
 
 revid_to_str(RevId) when size(RevId) =:= 16 ->
     ?l2b(couch_util:to_hex(RevId));

--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -280,12 +280,24 @@ validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
             throw({unknown_error, Message})
     end.
 
-json_doc(nil) -> null;
+json_doc_options() ->
+    json_doc_options([]).
+
+json_doc_options(Options) ->
+    Limit = config:get_integer("query_server_config", "revs_limit", 20),
+    [{revs, Limit} | Options].
+
 json_doc(Doc) ->
-    couch_doc:to_json_obj(Doc, [revs]).
+    json_doc(Doc, json_doc_options()).
+
+json_doc(nil, _) ->
+    null;
+json_doc(Doc, Options) ->
+    couch_doc:to_json_obj(Doc, Options).
 
 filter_view(DDoc, VName, Docs) ->
-    JsonDocs = [couch_doc:to_json_obj(Doc, [revs]) || Doc <- Docs],
+    Options = json_doc_options(),
+    JsonDocs = [json_doc(Doc, Options) || Doc <- Docs],
     [true, Passes] = ddoc_prompt(DDoc, [<<"views">>, VName, <<"map">>], [JsonDocs]),
     {ok, Passes}.
 
@@ -296,7 +308,8 @@ filter_docs(Req, Db, DDoc, FName, Docs) ->
     #httpd{} = HttpReq ->
         couch_httpd_external:json_req_obj(HttpReq, Db)
     end,
-    JsonDocs = [couch_doc:to_json_obj(Doc, [revs]) || Doc <- Docs],
+    Options = json_doc_options(),
+    JsonDocs = [json_doc(Doc, Options) || Doc <- Docs],
     [true, Passes] = ddoc_prompt(DDoc, [<<"filters">>, FName],
         [JsonDocs, JsonReq]),
     {ok, Passes}.

--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -268,14 +268,13 @@ get_number(Key, Props) ->
 validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
     JsonEditDoc = couch_doc:to_json_obj(EditDoc, [revs]),
     JsonDiskDoc = json_doc(DiskDoc),
-    Resp = ddoc_prompt(DDoc,
-                       [<<"validate_doc_update">>],
-                       [JsonEditDoc, JsonDiskDoc, Ctx, SecObj]),
-    case Resp of
-        _ when Resp /= 1 ->
-            couch_stats:increment_counter(
-                [couchdb, query_server, vdu_rejects], 1);
-        _ -> ok
+    Resp = ddoc_prompt(
+        DDoc,
+        [<<"validate_doc_update">>],
+        [JsonEditDoc, JsonDiskDoc, Ctx, SecObj]
+    ),
+    if Resp == 1 -> ok; true ->
+        couch_stats:increment_counter([couchdb, query_server, vdu_rejects], 1)
     end,
     case Resp of
         1 ->
@@ -311,10 +310,10 @@ filter_view(DDoc, VName, Docs) ->
 
 filter_docs(Req, Db, DDoc, FName, Docs) ->
     JsonReq = case Req of
-    {json_req, JsonObj} ->
-        JsonObj;
-    #httpd{} = HttpReq ->
-        couch_httpd_external:json_req_obj(HttpReq, Db)
+        {json_req, JsonObj} ->
+            JsonObj;
+        #httpd{} = HttpReq ->
+            couch_httpd_external:json_req_obj(HttpReq, Db)
     end,
     Options = json_doc_options(),
     JsonDocs = [json_doc(Doc, Options) || Doc <- Docs],

--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -256,7 +256,15 @@ get_number(Key, Props) ->
         throw({invalid_value, iolist_to_binary(Msg)})
     end.
 
+
 % use the function stored in ddoc.validate_doc_update to test an update.
+-spec validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) -> ok when
+    DDoc    :: ddoc(),
+    EditDoc :: doc(),
+    DiskDoc :: doc() | nil,
+    Ctx     :: user_ctx(),
+    SecObj  :: sec_obj().
+
 validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
     JsonEditDoc = couch_doc:to_json_obj(EditDoc, [revs]),
     JsonDiskDoc = json_doc(DiskDoc),


### PR DESCRIPTION
The existing revs_limit logic only accounts for depth of individual
branches, and ignores the case where you have a lot of branches, for
instance when a doc is heavily conflicted. This patch truncates the list
of revs when passing docs to the JS filter functions, because given
enough revs this can cause the couchjs processes to explode.
