### PR TITLE
Fix couchdb_os_daemons tests dependency.

### DIFF
--- a/test/couchdb_os_daemons_tests.erl
+++ b/test/couchdb_os_daemons_tests.erl
@@ -37,7 +37,7 @@
 
 
 setup(DName) ->
-    Ctx = test_util:start(?MODULE, [], [{dont_mock, [config]}]),
+    Ctx = test_util:start(?MODULE, [couch_log], [{dont_mock, [config]}]),
     {ok, OsDPid} = couch_os_daemons:start_link(),
     config:set("os_daemons", DName,
                      filename:join([?FIXTURESDIR, DName]), false),


### PR DESCRIPTION
couchdb_os_daemons_tests.erl was failing in
setup if run on its own:

```
... apps=couch tests=os_daemons_test_
```

with an exception:

```
**exit:{{{badmatch,undefined},
  [{couch_log,notice,2,[{file,"src/couch_log.erl"},{line,44}]},
   {config,handle_call,3,[{file,"src/config.erl"},{line,211}]},
```

because it depends on couch_log. So add couch_log as a dependency
in setup.

After fix it should run 5 tests:

```
[done in 5.626 s]
=======================================================
  Failed: 0.  Skipped: 0.  Passed: 5.
```

COUCHDB-2830