### PR TITLE
Fix OS Daemons test dependency.

### DIFF
--- a/test/couchdb_os_daemons_tests.erl
+++ b/test/couchdb_os_daemons_tests.erl
@@ -41,6 +41,9 @@ setup(DName) ->
     {ok, OsDPid} = couch_os_daemons:start_link(),
     config:set("os_daemons", DName,
                      filename:join([?FIXTURESDIR, DName]), false),
+    % Set configuration option to be used by configuration_reader_test_
+    % This will be used in os_daemon_configer.escript:test_get_cfg2
+    config:set("uuids", "algorithm","sequential", false),
     timer:sleep(?DELAY),  % sleep a bit to let daemon set kill flag
     {Ctx, OsDPid}.
 


### PR DESCRIPTION
In isolation was failing in configuration_reader_test_
Because fixtures/os_daemon_configer.escript was
requesting uuids.algorithm from config application,
which was not set up.

COUCHDB-2831