### PR TITLE
Remove round for create/delete database for 1000 times

### DIFF
--- a/test/couch_db_tests.erl
+++ b/test/couch_db_tests.erl
@@ -96,7 +96,7 @@ should_create_delete_database_continuously() ->
     couch_db:close(Db),
     [{timeout, ?TIMEOUT, {integer_to_list(N) ++ " times",
                            ?_assert(loop(DbName, N))}}
-     || N <- [10, 100, 1000]].
+     || N <- [10, 100]].
 
 loop(_, 0) ->
     true;


### PR DESCRIPTION
I'm not sure what we testing here except our disk drives healthiness.