### PR TITLE
Fix "initialization from incompatible pointer type" warning for icu drv

### DIFF
--- a/priv/icu_driver/couch_icu_driver.c
+++ b/priv/icu_driver/couch_icu_driver.c
@@ -30,11 +30,6 @@ specific language governing permissions and limitations under the License.
 #include <string.h> /* for memcpy */
 #endif
 
-#if ERL_DRV_EXTENDED_MAJOR_VERSION < 2
-typedef int COUCH_SSIZET;
-#else
-typedef ErlDrvSSizeT COUCH_SSIZET;
-#endif
 
 typedef struct {
     ErlDrvPort port;
@@ -85,9 +80,9 @@ static ErlDrvData couch_drv_start(ErlDrvPort port, char *buff)
     return (ErlDrvData)pData;
 }
 
-COUCH_SSIZET
+ErlDrvSSizeT
 return_control_result(void* pLocalResult, int localLen,
-            char **ppRetBuf, COUCH_SSIZET returnLen)
+            char **ppRetBuf, ErlDrvSizeT returnLen)
 {
     if (*ppRetBuf == NULL || localLen > returnLen) {
         *ppRetBuf = (char*)driver_alloc_binary(localLen);
@@ -99,10 +94,10 @@ return_control_result(void* pLocalResult, int localLen,
     return localLen;
 }
 
-static COUCH_SSIZET
+static ErlDrvSSizeT
 couch_drv_control(ErlDrvData drv_data, unsigned int command,
-        char *pBuf, COUCH_SSIZET bufLen,
-        char **rbuf, COUCH_SSIZET rlen)
+        char *pBuf, ErlDrvSizeT bufLen,
+        char **rbuf, ErlDrvSizeT rlen)
 {
 
     couch_drv_data* pData = (couch_drv_data*)drv_data;


### PR DESCRIPTION
It was caused by using ErlDrvSSizeT type instead of ErlDrvSizeT. It
was not an issue prior to R15 when ErlDrvSSizeT and ErlDrvSizeT where
basically int's.

Since we raised minimal Erlang release requirement up to R16B03-1,
there is no reason to maintain compatibility with pre-R15 for driver
so local COUCH_* types are replaced with ErlDrv* ones.