### PR TITLE
Handle view server crashing during test compile of view functions.

### DIFF
--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -38,10 +38,15 @@ try_compile(Proc, FunctionType, FunctionName, FunctionSource) ->
     try
         proc_prompt(Proc, [<<"add_fun">>, FunctionSource]),
         ok
-    catch {compilation_error, E} ->
-        Fmt = "Compilation of the ~s function in the '~s' view failed: ~s",
-        Msg = io_lib:format(Fmt, [FunctionType, FunctionName, E]),
-        throw({compilation_error, Msg})
+    catch
+        {compilation_error, E} ->
+            Fmt = "Compilation of the ~s function in the '~s' view failed: ~s",
+            Msg = io_lib:format(Fmt, [FunctionType, FunctionName, E]),
+            throw({compilation_error, Msg});
+        {os_process_error, {exit_status, ExitStatus}} ->
+            Fmt = "Compilation of the ~s function in the '~s' view failed with exit status: ~p",
+            Msg = io_lib:format(Fmt, [FunctionType, FunctionName, ExitStatus]),
+            throw({compilation_error, Msg})
     end.
 
 start_doc_map(Lang, Functions, Lib) ->


### PR DESCRIPTION
Due to how libmozjs185 library is compiled on Ubuntu 12.04, given
invalid JS code, it will not return with expected error result:

 ["error","compilation_error",...]

but will crash. Otherwise library seems functional --  it passes
all other mrview tests.

Handle this crash in try_compile() function as a compilation
failure. Error message contains the exit status of the view process
to help debugging.