### PR TITLE
Stabilize couch_task_status_tests:run_multiple_tasks/0 test.

### DIFF
--- a/test/couch_task_status_tests.erl
+++ b/test/couch_task_status_tests.erl
@@ -180,6 +180,16 @@ loop() ->
             From ! {ok, self(), ok}
     end.
 
+call(Pid, done) ->
+    Ref = erlang:monitor(process, Pid),
+    Pid ! {done, self()},
+    Res = wait(Pid),
+    receive
+        {'DOWN', Ref, _Type, Pid, _Info} ->
+            Res
+    after ?TIMEOUT ->
+            throw(timeout_error)
+    end;
 call(Pid, Command) ->
     Pid ! {Command, self()},
     wait(Pid).


### PR DESCRIPTION
Previously, at the end of the test, it kills each status process
with call(Pid1, done), then immediately calls couch_task_status:all().

This caused a race between couch_task_status receiving the 'all'
call and the 'DOWN' message (from monitoring test processes). If
'DOWN' message came before 'all', test passed. If it came
after, it failed.