### PR TITLE
Fix race condition in workqueue test.

### DIFF
--- a/test/couch_work_queue_tests.erl
+++ b/test/couch_work_queue_tests.erl
@@ -206,7 +206,7 @@ should_block_producer_on_full_queue_count({Q, Producer, _}) ->
     ?assertEqual(2, couch_work_queue:item_count(Q)),
     ok = ping(Producer),
 
-    produce(Q, Producer, 20, false),
+    produce(Q, Producer, 20, true),
     ?assertEqual(3, couch_work_queue:item_count(Q)),
     Pong = ping(Producer),
 


### PR DESCRIPTION
Failure seen at least once in about 150 test runs:

```
Queue with max size of 160 bytes and 3 max items
 couch_work_queue_tests:143: should_have_no_items_for_new_queue...ok
**error:{assertEqual_failed,[{module,couch_work_queue_tests},
                     {line,210},
                     {expression,"couch_work_queue : item_count ( Q )"},
                     {expected,3},
                     {value,2}]}
```

From

```
should_block_producer_on_full_queue_count({Q, Producer, _}) ->
    ...
    produce(Q, Producer, 20, false),
    ?assertEqual(3, couch_work_queue:item_count(Q)),
```

Race condition is: telling Producer to produce, not waiting
for queue size to be updated, and then immediately checking
item_count.

To make failure occur reliably insert timer:sleep(10) in
producer_loop after ```Parent ! {item, Ref, Item}``` line.

The fix is to wait for queue size to be updated by using
the wait mode for produce function.

COUCHDB-2848