### PR TITLE
Add chttpd_plugin:before_response/4 hook

### DIFF
--- a/src/couch_httpd_cors.erl
+++ b/src/couch_httpd_cors.erl
@@ -171,15 +171,8 @@ handle_preflight_request(Origin, Host, MochiReq) ->
         end
     end.
 
-
-send_preflight_response(#httpd{mochi_req=MochiReq}=Req, Headers) ->
-    couch_httpd:log_request(Req, 204),
-    couch_stats:increment_counter([couchdb, httpd_status_codes, 204]),
-    Headers1 = couch_httpd:http_1_0_keep_alive(MochiReq, Headers),
-    Headers2 = Headers1 ++ couch_httpd:server_header() ++
-               couch_httpd_auth:cookie_auth_header(Req, Headers1),
-    {ok, MochiReq:respond({204, Headers2, <<>>})}.
-
+send_preflight_response(Req, Headers) ->
+    couch_httpd:send_response(Req, 204, Headers, {io_list, <<>>}).
 
 % cors_headers/1
 

--- a/src/couch_httpd_oauth.erl
+++ b/src/couch_httpd_oauth.erl
@@ -292,8 +292,8 @@ sig_method_1(_) ->
     undefined.
 
 
-ok(#httpd{mochi_req=MochiReq}, Body) ->
-    {ok, MochiReq:respond({200, [], Body})}.
+ok(Req, Body) ->
+    couch_httpd:send_response(Req, 200, [], {io_list, Body}).
 
 
 oauth_credentials_info(Token, ConsumerKey) ->


### PR DESCRIPTION
This hook is useful in following casses:

  - to inject vendor specific headers
  - to inject vendor keys into json objects returned to client
  - to override return code