### PR TITLE
Add couch_file:open_files/0

### DIFF
--- a/src/couch_debug.erl
+++ b/src/couch_debug.erl
@@ -1,0 +1,33 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_debug).
+
+-export([opened_files/0]).
+
+-spec opened_files() ->
+    [{port(), CouchFilePid :: pid(), Fd :: pid() | tuple(), FilePath :: string()}].
+
+opened_files() ->
+    Info = [couch_file_port_info(Port)
+        || Port <- erlang:ports(),
+            {name, "efile"} =:= erlang:port_info(Port, name)],
+    [I || I <- Info, is_tuple(I)].
+
+couch_file_port_info(Port) ->
+    {connected, Pid} = erlang:port_info(Port, connected),
+    case couch_file:process_info(Pid) of
+        {Fd, FilePath} ->
+            {Port, Pid, Fd, FilePath};
+        undefined ->
+            undefined
+    end.


### PR DESCRIPTION
Adding debugging function to list all opened couch_file files.
This function is for debugging purposes only. It iterates through all
open ports and returns file descriptor and filename correspondent to
every port.