### PR TITLE
Send a real EventSource event for heartbeat

### DIFF
--- a/src/couch_httpd_db.erl
+++ b/src/couch_httpd_db.erl
@@ -111,6 +111,8 @@ handle_changes_req1(Req, #db{name=DbName}=Db, ChangesArgs, ChangesFun) ->
                 io_lib:format("\n],\n\"last_seq\":~w}\n", [EndSeq])
             ),
             couch_httpd:end_json_response(Resp);
+        (timeout, "eventsource") ->
+            couch_httpd:send_chunk(Resp, "event: heartbeat\ndata: \n\n");
         (timeout, _) ->
             couch_httpd:send_chunk(Resp, "\n")
         end


### PR DESCRIPTION
Bring back 845bf7529a3bc565d6446a7fa6cc5fd1a140653e

The EventSource connection can get stuck (in TCP half-open state*) and there's no way
for the client to detect that. This commit changes the way heartbeat is sent, instead of
sending a newline character, it sends an empty event of type heartbeat:

    event: heartbeat
    data:

This event doesn't have an id: field, so the client will retain its latest Last-Event-ID state.

This doesn't change the expectations of clients that used EventSource till now, because they
subscribe to the 'message' event type. To get the 'heartbeat' events a client will need to
explicitly subscribe to it:

    source.addEventListener('heartbeat', function () { /* cancel a timer that would otherwise reconnect the source */ });

* this can happen when you suspend your laptop, on flaky internet connection, ADSL reconnect,
bad wifi signals, bad routers etc. Pretty often in a typical internet usage nowadays.