### PR TITLE
Refactor rename on delete

### DIFF
--- a/src/couch_db_updater.erl
+++ b/src/couch_db_updater.erl
@@ -43,9 +43,10 @@ init({DbName, Filepath, Fd, Options}) ->
         ok = couch_file:write_header(Fd, Header),
         % delete any old compaction files that might be hanging around
         RootDir = config:get("couchdb", "database_dir", "."),
-        couch_server:delete_file(RootDir, Filepath ++ ".compact"),
-        couch_server:delete_file(RootDir, Filepath ++ ".compact.data"),
-        couch_server:delete_file(RootDir, Filepath ++ ".compact.meta");
+        DelOpts = [compaction],
+        couch_server:delete_file(RootDir, Filepath ++ ".compact", DelOpts),
+        couch_server:delete_file(RootDir, Filepath ++ ".compact.data",DelOpts),
+        couch_server:delete_file(RootDir, Filepath ++ ".compact.meta",DelOpts);
     false ->
         case couch_file:read_header(Fd) of
         {ok, Header} ->
@@ -105,7 +106,8 @@ handle_call(cancel_compact, _From, #db{compactor_pid = Pid} = Db) ->
     unlink(Pid),
     exit(Pid, kill),
     RootDir = config:get("couchdb", "database_dir", "."),
-    {ok, _} = couch_server:delete_file(RootDir, Db#db.filepath ++ ".compact"),
+    {ok, _} = couch_server:delete_file(RootDir, Db#db.filepath ++ ".compact",
+        [compaction]),
     Db2 = Db#db{compactor_pid = nil},
     ok = gen_server:call(couch_server, {db_updated, Db2}, infinity),
     {reply, ok, Db2};
@@ -246,11 +248,12 @@ handle_cast({compact_done, CompactFilepath}, #db{filepath=Filepath}=Db) ->
                         [Filepath, CompactFilepath]),
         ok = file:rename(CompactFilepath, Filepath ++ ".compact"),
         RootDir = config:get("couchdb", "database_dir", "."),
-        couch_server:delete_file(RootDir, Filepath),
+        couch_server:delete_file(RootDir, Filepath, [compaction]),
         ok = file:rename(Filepath ++ ".compact", Filepath),
         % Delete the old meta compaction file after promoting
         % the compaction file.
-        couch_server:delete_file(RootDir, Filepath ++ ".compact.meta"),
+        couch_server:delete_file(RootDir, Filepath ++ ".compact.meta",
+            [compaction]),
         close_db(Db),
         NewDb3 = refresh_validate_doc_funs(NewDb2),
         ok = gen_server:call(couch_server, {db_updated, NewDb3}, infinity),

--- a/src/couch_db_updater.erl
+++ b/src/couch_db_updater.erl
@@ -43,10 +43,8 @@ init({DbName, Filepath, Fd, Options}) ->
         ok = couch_file:write_header(Fd, Header),
         % delete any old compaction files that might be hanging around
         RootDir = config:get("couchdb", "database_dir", "."),
-        DelOpts = [compaction],
-        couch_server:delete_file(RootDir, Filepath ++ ".compact", DelOpts),
-        couch_server:delete_file(RootDir, Filepath ++ ".compact.data",DelOpts),
-        couch_server:delete_file(RootDir, Filepath ++ ".compact.meta",DelOpts);
+        couch_server:delete_with_exts(RootDir, Filepath,
+            [".compact", ".compact.data", ".compact.meta"], [compaction]);
     false ->
         case couch_file:read_header(Fd) of
         {ok, Header} ->

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -225,7 +225,11 @@ delete(RootDir, Filepath, Options) ->
     DelFile = deleted_filename(RootDir, Filepath, Rename and not Compaction),
     case file:rename(Filepath, DelFile) of
         ok when Rename ->
-            update_mtime(DelFile);
+            Now = calendar:local_time(),
+            case file:change_time(DelFile, Now) of
+                ok -> {ok, {renamed, DelFile}};
+                Else -> Else
+            end;
         ok when Async ->
             spawn(fun() -> delete_file(DelFile) end),
             {ok, deleted};
@@ -233,13 +237,6 @@ delete(RootDir, Filepath, Options) ->
             delete_file(DelFile);
         Error ->
             Error
-    end.
-
-update_mtime(FilePath) ->
-    Now = calendar:local_time(),
-    case file:change_time(FilePath, Now) of
-        ok -> {ok, {renamed, FilePath}};
-        Else -> Else
     end.
 
 delete_file(FilePath) ->
@@ -295,7 +292,7 @@ rename_dir(Original) ->
             Suffix = deleted_filename_suffix(),
             DelDir = io_lib:format("~s.~s.deleted", [Original, Suffix]),
             ok = file:rename(Original, DelDir),
-            update_mtime(DelDir);
+            ok = file:change_time(DelDir, calendar:local_time());
         false ->
             ok
     end.

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -268,7 +268,7 @@ deleted_filename_base(RootDir, FullPath) ->
     {ok, MP} = re:compile(RegExp),
     {match, Tokens} = re:run(FullPath, MP, [{capture, all_but_first, list}]),
     Name0 = string:join([T || T <- Tokens, T /= []], "/"),
-    re:replace(Name0, "/", ":", [global, {return, list}]).
+    re:replace(Name0, "/", "#", [global, {return, list}]).
 
 deleted_filename_suffix() ->
     {{Y, Mon, D}, {H, Min, S}} = calendar:universal_time(),
@@ -702,14 +702,14 @@ make_plain_fixtures(DbNames) ->
             "/srv/data/views"
                 "/.~s_design/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
             ["/srv/data/views"
-                "/.delete/.~s_design:3133e28517e89a3e11435dd5ac4ad85a",".view"]
+                "/.delete/.~s_design#3133e28517e89a3e11435dd5ac4ad85a",".view"]
         },
         {
             "/srv/data/dbs",
             "/srv/data/dbs/shards/"
                 "00000000-1fffffff/~s.1458336317.couch",
             ["/srv/data/dbs/.delete/"
-                "00000000-1fffffff:~s.1458336317", ".couch"]
+                "00000000-1fffffff#~s.1458336317", ".couch"]
         },
         {
             "/srv/data/views",
@@ -717,8 +717,8 @@ make_plain_fixtures(DbNames) ->
                 "00000000-1fffffff/~s.1458336317_design"
                 "/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
             ["/srv/data/views/.delete/"
-                "00000000-1fffffff:~s.1458336317_design"
-                ":3133e28517e89a3e11435dd5ac4ad85a", ".view"]
+                "00000000-1fffffff#~s.1458336317_design"
+                "#3133e28517e89a3e11435dd5ac4ad85a", ".view"]
         }
     ],
     lists:flatmap(fun(DbName) ->
@@ -737,21 +737,21 @@ make_deep_fixtures(UserNames, DbNames) ->
         {
             "/srv/data/dbs",
             "/srv/data/dbs/~s/~s.couch",
-            ["/srv/data/dbs/.delete/~s:~s", ".couch"]
+            ["/srv/data/dbs/.delete/~s#~s", ".couch"]
         },
         {
             "/srv/data/views",
             "/srv/data/views"
                 "/.~s/.~s_design/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
             ["/srv/data/views/.delete/"
-                ".~s:.~s_design:3133e28517e89a3e11435dd5ac4ad85a", ".view"]
+                ".~s#.~s_design#3133e28517e89a3e11435dd5ac4ad85a", ".view"]
         },
         {
             "/srv/data/dbs",
             "/srv/data/dbs/shards/"
                 "00000000-1fffffff/~s/~s.1458336317.couch",
             ["/srv/data/dbs/.delete/"
-                "00000000-1fffffff:~s:~s.1458336317", ".couch"]
+                "00000000-1fffffff#~s#~s.1458336317", ".couch"]
         },
         {
             "/srv/data/views",
@@ -759,13 +759,13 @@ make_deep_fixtures(UserNames, DbNames) ->
                 "00000000-1fffffff/~s/~s.1458336317_design"
                 "/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
             ["/srv/data/views/.delete/"
-                "00000000-1fffffff:~s:~s.1458336317_design"
-                ":3133e28517e89a3e11435dd5ac4ad85a", ".view"]
+                "00000000-1fffffff#~s#~s.1458336317_design"
+                "#3133e28517e89a3e11435dd5ac4ad85a", ".view"]
         }
     ],
     Variants = [[U, D] || U <- UserNames, D <- DbNames],
     lists:flatmap(fun([UserName, DbName]) ->
-        UserName1 = re:replace(UserName, "/", ":", [global, {return, list}]),
+        UserName1 = re:replace(UserName, "/", "#", [global, {return, list}]),
         lists:map(fun({RootDir, BeforeFmt, [AfterFmt, Ext]}) ->
             {
                 RootDir,

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -220,8 +220,9 @@ close(Fd) ->
 
 delete(RootDir, Filepath, Options) ->
     Async = not lists:member(sync, Options),
+    Compaction = lists:member(compaction, Options),
     Rename = lists:member(rename, Options),
-    DelFile = deleted_filename(RootDir, Filepath, Rename),
+    DelFile = deleted_filename(RootDir, Filepath, Rename and not Compaction),
     case file:rename(Filepath, DelFile) of
         ok when Rename ->
             update_mtime(DelFile);

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -259,10 +259,10 @@ deleted_filename(Original, Ending) ->
     io_lib:format("~s.~s.~s~s", [RootName, Suffix, Ending, Extention]).
 
 deleted_filename_base(RootDir, FullPath) ->
-    Shard = "\.?shards/([0-9a-f]{8}-[0-9a-f]{8})",
+    Shard = "\\.?shards/([0-9a-f]{8}-[0-9a-f]{8})",
     User = "\\.?(.+)",
-    ViewFile = "(?:mrview/(.+\.view))",
-    DbFile = "(.+\.couch)",
+    ViewFile = "(?:mrview/(.+\\.view))",
+    DbFile = "(.+\\.couch)",
     Pattern = "^~s(?:/~s)?(?:/~s)?(?:/(?:~s|~s))$",
     RegExp =  io_lib:format(Pattern, [RootDir, Shard, User, ViewFile, DbFile]),
     {ok, MP} = re:compile(RegExp),

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -224,7 +224,7 @@ delete(RootDir, Filepath, Options) ->
     DelFile = deleted_filename(RootDir, Filepath, Rename),
     case file:rename(Filepath, DelFile) of
         ok when Rename ->
-            {ok, {renamed, DelFile}};
+            update_mtime(DelFile);
         ok when Async ->
             spawn(fun() -> delete_file(DelFile) end),
             {ok, deleted};
@@ -232,6 +232,13 @@ delete(RootDir, Filepath, Options) ->
             delete_file(DelFile);
         Error ->
             Error
+    end.
+
+update_mtime(FilePath) ->
+    Now = calendar:local_time(),
+    case file:change_time(FilePath, Now) of
+        ok -> {ok, {renamed, FilePath}};
+        Else -> Else
     end.
 
 delete_file(FilePath) ->

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -36,7 +36,7 @@
 -export([append_raw_chunk/2, assemble_file_chunk/1, assemble_file_chunk/2]).
 -export([append_term/2, append_term/3, append_term_md5/2, append_term_md5/3]).
 -export([write_header/2, read_header/1]).
--export([delete/3, nuke_dir/2, init_delete_dir/1]).
+-export([delete/3, nuke_dir/2, rename_dir/1, init_delete_dir/1]).
 
 % gen_server callbacks
 -export([init/1, terminate/2, code_change/3]).
@@ -288,6 +288,16 @@ nuke_dir(RootDelDir, Dir) ->
             ok
     end.
 
+rename_dir(Original) ->
+    case filelib:is_dir(Original) of
+        true ->
+            Suffix = deleted_filename_suffix(),
+            DelDir = io_lib:format("~s.~s.deleted", [Original, Suffix]),
+            ok = file:rename(Original, DelDir),
+            update_mtime(DelDir);
+        false ->
+            ok
+    end.
 
 init_delete_dir(RootDir) ->
     Dir = filename:join(RootDir,".delete"),

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -262,7 +262,7 @@ deleted_filename_base(RootDir, FullPath) ->
     Shard = "\\.?shards/([0-9a-f]{8}-[0-9a-f]{8})",
     User = "\\.?(.+)",
     ViewFile = "(?:mrview/(.+\\.view))",
-    DbFile = "(.+\\.couch)",
+    DbFile = "(.+\\.couch.*)",
     Pattern = "^~s(?:/~s)?(?:/~s)?(?:/(?:~s|~s))$",
     RegExp =  io_lib:format(Pattern, [RootDir, Shard, User, ViewFile, DbFile]),
     {ok, MP} = re:compile(RegExp),
@@ -698,6 +698,16 @@ make_plain_fixtures(DbNames) ->
             ["/srv/data/dbs/.delete/~s", ".couch"]
         },
         {
+            "/srv/data/dbs",
+            "/srv/data/dbs/~s.couch.compact",
+            ["/srv/data/dbs/.delete/~s.couch", ".compact"]
+        },
+        {
+            "/srv/data/dbs",
+            "/srv/data/dbs/~s.couch.meta",
+            ["/srv/data/dbs/.delete/~s.couch", ".meta"]
+        },
+        {
             "/srv/data/views",
             "/srv/data/views"
                 "/.~s_design/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
@@ -710,6 +720,20 @@ make_plain_fixtures(DbNames) ->
                 "00000000-1fffffff/~s.1458336317.couch",
             ["/srv/data/dbs/.delete/"
                 "00000000-1fffffff#~s.1458336317", ".couch"]
+        },
+        {
+            "/srv/data/dbs",
+            "/srv/data/dbs/shards/"
+                "00000000-1fffffff/~s.1458336317.couch.compact",
+            ["/srv/data/dbs/.delete/"
+                "00000000-1fffffff#~s.1458336317.couch", ".compact"]
+        },
+        {
+            "/srv/data/dbs",
+            "/srv/data/dbs/shards/"
+                "00000000-1fffffff/~s.1458336317.couch.meta",
+            ["/srv/data/dbs/.delete/"
+                "00000000-1fffffff#~s.1458336317.couch", ".meta"]
         },
         {
             "/srv/data/views",
@@ -740,6 +764,16 @@ make_deep_fixtures(UserNames, DbNames) ->
             ["/srv/data/dbs/.delete/~s#~s", ".couch"]
         },
         {
+            "/srv/data/dbs",
+            "/srv/data/dbs/~s/~s.couch.compact",
+            ["/srv/data/dbs/.delete/~s#~s.couch", ".compact"]
+        },
+        {
+            "/srv/data/dbs",
+            "/srv/data/dbs/~s/~s.couch.meta",
+            ["/srv/data/dbs/.delete/~s#~s.couch", ".meta"]
+        },
+        {
             "/srv/data/views",
             "/srv/data/views"
                 "/.~s/.~s_design/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
@@ -752,6 +786,20 @@ make_deep_fixtures(UserNames, DbNames) ->
                 "00000000-1fffffff/~s/~s.1458336317.couch",
             ["/srv/data/dbs/.delete/"
                 "00000000-1fffffff#~s#~s.1458336317", ".couch"]
+        },
+        {
+            "/srv/data/dbs",
+            "/srv/data/dbs/shards/"
+                "00000000-1fffffff/~s/~s.1458336317.couch.compact",
+            ["/srv/data/dbs/.delete/"
+                "00000000-1fffffff#~s#~s.1458336317.couch", ".compact"]
+        },
+        {
+            "/srv/data/dbs",
+            "/srv/data/dbs/shards/"
+                "00000000-1fffffff/~s/~s.1458336317.couch.meta",
+            ["/srv/data/dbs/.delete/"
+                "00000000-1fffffff#~s#~s.1458336317.couch", ".meta"]
         },
         {
             "/srv/data/views",

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -260,7 +260,7 @@ deleted_filename(Original, Ending) ->
 
 deleted_filename_base(RootDir, FullPath) ->
     Shard = "\.?shards/([0-9a-f]{8}-[0-9a-f]{8})",
-    User = "(.+)",
+    User = "\\.?(.+)",
     ViewFile = "(?:mrview/(.+\.view))",
     DbFile = "(.+\.couch)",
     Pattern = "^~s(?:/~s)?(?:/~s)?(?:/(?:~s|~s))$",
@@ -702,7 +702,7 @@ make_plain_fixtures(DbNames) ->
             "/srv/data/views"
                 "/.~s_design/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
             ["/srv/data/views"
-                "/.delete/.~s_design#3133e28517e89a3e11435dd5ac4ad85a",".view"]
+                "/.delete/~s_design#3133e28517e89a3e11435dd5ac4ad85a", ".view"]
         },
         {
             "/srv/data/dbs",
@@ -744,7 +744,7 @@ make_deep_fixtures(UserNames, DbNames) ->
             "/srv/data/views"
                 "/.~s/.~s_design/mrview/3133e28517e89a3e11435dd5ac4ad85a.view",
             ["/srv/data/views/.delete/"
-                ".~s#.~s_design#3133e28517e89a3e11435dd5ac4ad85a", ".view"]
+                "~s#.~s_design#3133e28517e89a3e11435dd5ac4ad85a", ".view"]
         },
         {
             "/srv/data/dbs",

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -457,7 +457,6 @@ handle_call({delete, DbName, Options}, _From, Server) ->
         lists:foreach(fun(Ext) ->
             delete_file(Server#server.root_dir, FullFilepath ++ Ext)
         end, [".compact", ".compact.data", ".compact.meta"]),
-        couch_file:delete(Server#server.root_dir, FullFilepath ++ ".compact"),
 
         couch_db_plugin:on_delete(DbName, Options),
 

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -25,7 +25,7 @@
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
 
--export([delete_file/2, delete_file/3]).
+-export([delete_file/2, delete_file/3, delete_dir/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -547,4 +547,12 @@ delete_file(RootDir, FullFilePath, Options) ->
             couch_file:delete(RootDir, FullFilePath, [rename | Options]);
         false ->
             couch_file:delete(RootDir, FullFilePath, Options)
+    end.
+
+delete_dir(RootDelDir, Dir) ->
+    case config:get_boolean("couchdb", "rename_on_delete", false) of
+        true ->
+            couch_file:rename_dir(Dir);
+        false ->
+            couch_file:nuke_dir(RootDelDir, Dir)
     end.

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -542,6 +542,9 @@ delete_file(RootDir, FullFilePath) ->
     delete_file(RootDir, FullFilePath, []).
 
 delete_file(RootDir, FullFilePath, Options) ->
-    Async = not lists:member(sync, Options),
-    RenameOnDelete = config:get_boolean("couchdb", "rename_on_delete", false),
-    couch_file:delete(RootDir, FullFilePath, Async, RenameOnDelete).
+    case config:get_boolean("couchdb", "rename_on_delete", false) of
+        true ->
+            couch_file:delete(RootDir, FullFilePath, [rename | Options]);
+        false ->
+            couch_file:delete(RootDir, FullFilePath, Options)
+    end.


### PR DESCRIPTION
The goals of this PR.
- move `rename_on_delete` feature into `couch_file`
- avoid calling `config` from `couch_file`