### PR TITLE
2966 before response hook

### DIFF
--- a/src/couch_httpd.erl
+++ b/src/couch_httpd.erl
@@ -476,11 +476,14 @@ accepted_encodings(#httpd{mochi_req=MochiReq}) ->
 serve_file(Req, RelativePath, DocumentRoot) ->
     serve_file(Req, RelativePath, DocumentRoot, []).
 
-serve_file(#httpd{mochi_req=MochiReq}=Req, RelativePath, DocumentRoot,
-           ExtraHeaders) ->
-    log_request(Req, 200),
-    Headers = basic_headers(Req, ExtraHeaders),
-    {ok, MochiReq:serve_file(RelativePath, DocumentRoot, Headers)}.
+serve_file(Req0, RelativePath0, DocumentRoot0, ExtraHeaders) ->
+    Headers0 = basic_headers(Req0, ExtraHeaders),
+    {ok, {Req1, Code1, Headers1, RelativePath1, DocumentRoot1}} =
+        chttpd_plugin:before_serve_file(
+            Req0, 200, Headers0, RelativePath0, DocumentRoot0),
+    log_request(Req1, Code1),
+    #httpd{mochi_req = MochiReq} = Req1,
+    {ok, MochiReq:serve_file(RelativePath1, DocumentRoot1, Headers1)}.
 
 qs_value(Req, Key) ->
     qs_value(Req, Key, undefined).

--- a/src/couch_httpd.erl
+++ b/src/couch_httpd.erl
@@ -1117,10 +1117,12 @@ basic_headers_no_cors(Req, Headers) ->
         ++ server_header()
         ++ couch_httpd_auth:cookie_auth_header(Req, Headers).
 
-handle_response(Req, Code, Headers, Args, Type) ->
-    log_request(Req, Code),
-    couch_stats:increment_counter([couchdb, httpd_status_codes, Code]),
-    respond_(Req, Code, Headers, Args, Type).
+handle_response(Req0, Code0, Headers0, Args0, Type) ->
+    {ok, {Req1, Code1, Headers1, Args1}} =
+        chttpd_plugin:before_response(Req0, Code0, Headers0, Args0),
+    couch_stats:increment_counter([couchdb, httpd_status_codes, Code1]),
+    log_request(Req0, Code1),
+    respond_(Req1, Code1, Headers1, Args1, Type).
 
 respond_(#httpd{mochi_req = MochiReq}, Code, Headers, _Args, start_response) ->
     MochiReq:start_response({Code, Headers});


### PR DESCRIPTION
Implement `before_response` and `before_serve_file` EPI hooks.

These hooks are useful in following cases:

 - to inject vendor specific headers
 - to inject vendor keys into json objects returned to client
 - to override return code

This is a replacement PR for #133