### PR TITLE
Use couch_tests applications for couch_db_plugin_tests

### DIFF
--- a/test/couch_db_plugin_tests.erl
+++ b/test/couch_db_plugin_tests.erl
@@ -47,7 +47,7 @@ notify(_, _, _) -> ok.
 setup() ->
     couch_tests:setup([
         couch_epi_dispatch:dispatch(chttpd, ?MODULE)
-    ], [], []).
+    ]).
 
 teardown(Ctx) ->
     couch_tests:teardown(Ctx).

--- a/test/couch_db_plugin_tests.erl
+++ b/test/couch_db_plugin_tests.erl
@@ -45,15 +45,12 @@ processes() -> [].
 notify(_, _, _) -> ok.
 
 setup() ->
-    application:stop(couch_epi), % in case it's already running from other tests...
-    application:unload(couch_epi),
-    ok = application:load(couch_epi),
-    ok = application:set_env(couch_epi, plugins, [?MODULE]), % only this plugin
-    ok = application:start(couch_epi).
+    couch_tests:setup([
+        couch_epi_dispatch:dispatch(chttpd, ?MODULE)
+    ], [], []).
 
-teardown(_) ->
-    ok = application:stop(couch_epi),
-    ok = application:unload(couch_epi).
+teardown(Ctx) ->
+    couch_tests:teardown(Ctx).
 
 validate_dbname({true, _Db}, _) -> true;
 validate_dbname({false, _Db}, _) -> false;


### PR DESCRIPTION
This fixes the problem with chttpd_plugin_tests. Previously following would fail:
```
make eunit apps=couch,chttpd tests=callback_test,error_info_test
```
In order to test this PR you would need to add apache/couchdb-erlang-tests#1 as a dependency in `rebar.config.script`. You might need to add the app into `rel/reltool.config` as well.
