### PR TITLE
Use the {minor_version, 1} option on the term_to_binary call to expli…

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -873,7 +873,7 @@ new_revid(#doc{body=Body, revs={OldStart,OldRevs}, atts=Atts, deleted=Deleted}) 
             ?l2b(integer_to_list(couch_util:rand32()));
         Atts2 ->
             OldRev = case OldRevs of [] -> 0; [OldRev0|_] -> OldRev0 end,
-            couch_crypto:hash(md5, term_to_binary([Deleted, OldStart, OldRev, Body, Atts2]))
+            couch_crypto:hash(md5, term_to_binary([Deleted, OldStart, OldRev, Body, Atts2], {minor_version, 1)))
     end.
 
 new_revs([], OutBuckets, IdRevsAcc) ->


### PR DESCRIPTION
…citly use the 64-bit IEEE float format for calculating the MD5.

This makes encoding consistent between OTP releases both before and after 17.0, and helps third parties replicate the md5 revision id calculation.