### PR TITLE
Use {minor_version, 1} on term_to_binary call for MD5 of _rev id

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -873,7 +873,7 @@ new_revid(#doc{body=Body, revs={OldStart,OldRevs}, atts=Atts, deleted=Deleted}) 
             ?l2b(integer_to_list(couch_util:rand32()));
         Atts2 ->
             OldRev = case OldRevs of [] -> 0; [OldRev0|_] -> OldRev0 end,
-            couch_crypto:hash(md5, term_to_binary([Deleted, OldStart, OldRev, Body, Atts2]))
+            couch_crypto:hash(md5, term_to_binary([Deleted, OldStart, OldRev, Body, Atts2], [{minor_version, 1}]))
     end.
 
 new_revs([], OutBuckets, IdRevsAcc) ->


### PR DESCRIPTION

This uses the 64-bit IEEE format for floats, making the binary representation consistent between OTP versions before and after 17.0.
This also makes it easier for third parties to replicate the md5 portion of the revision id calculation.