### PR TITLE
Add capability for compaction on local update

### DIFF
--- a/src/couch_db_updater.erl
+++ b/src/couch_db_updater.erl
@@ -294,6 +294,10 @@ handle_info({update_docs, Client, GroupedDocs, NonRepDocs, MergeConflicts,
             couch_event:notify(Db2#db.name, updated);
         true -> ok
         end,
+        if NonRepDocs2 /= [] ->
+            couch_event:notify(Db2#db.name, local_updated);
+        true -> ok
+        end,
         [catch(ClientPid ! {done, self()}) || ClientPid <- Clients],
         Db3 = case length(UpdatedDDocIds) > 0 of
             true ->


### PR DESCRIPTION
Prior to this commit, there was no functionality for a custom compactor
to know if the local database had been updated. This commit adds a
local_updated event, which will inform custom compactors when the local
tree has been updated.