### PR TITLE
Redo `enable_database_recovery` behaviour

### DIFF
--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -219,12 +219,14 @@ close(Fd) ->
 
 
 delete(RootDir, Filepath) ->
-    delete(RootDir, Filepath, true).
+    delete(RootDir, Filepath, []).
 
-delete(RootDir, FullFilePath, Async) ->
+delete(RootDir, FullFilePath, Options) ->
     EnableRecovery = config:get_boolean("couchdb",
         "enable_database_recovery", false),
-    case EnableRecovery of
+    Async = not lists:member(sync, Options),
+    Context = couch_util:get_value(context, Options, compaction),
+    case Context =:= delete andalso EnableRecovery of
         true ->
             rename_file(FullFilePath);
         false ->

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -246,7 +246,11 @@ delete_file(RootDir, Filepath, Async) ->
 
 rename_file(Original) ->
     DeletedFileName = deleted_filename(Original),
-    file:rename(Original, DeletedFileName).
+    Now = calendar:local_time(),
+    case file:rename(Original, DeletedFileName) of
+        ok -> file:change_time(DeletedFileName, Now);
+        Else -> Else
+    end.
 
 deleted_filename(Original) ->
     {{Y, Mon, D}, {H, Min, S}} = calendar:universal_time(),

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -264,6 +264,18 @@ deleted_filename(Original) ->
     filename:rootname(Original) ++ Suffix.
 
 nuke_dir(RootDelDir, Dir) ->
+    EnableRecovery = config:get_boolean("couchdb",
+        "enable_database_recovery", false),
+    case EnableRecovery of
+        true ->
+            rename_file(Dir);
+        false ->
+            delete_dir(RootDelDir, Dir)
+    end.
+
+delete_dir(RootDelDir, Dir) ->
+    DeleteAfterRename = config:get_boolean("couchdb",
+        "delete_after_rename", true),
     FoldFun = fun(File) ->
         Path = Dir ++ "/" ++ File,
         case filelib:is_dir(Path) of
@@ -271,7 +283,7 @@ nuke_dir(RootDelDir, Dir) ->
                 ok = nuke_dir(RootDelDir, Path),
                 file:del_dir(Path);
             false ->
-                delete(RootDelDir, Path, false)
+                delete_file(RootDelDir, Path, false, DeleteAfterRename)
         end
     end,
     case file:list_dir(Dir) of

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -228,21 +228,23 @@ delete(RootDir, FullFilePath, Async) ->
         true ->
             rename_file(FullFilePath);
         false ->
-            delete_file(RootDir, FullFilePath, Async)
+            DeleteAfterRename = config:get_boolean("couchdb",
+                "delete_after_rename", true),
+            delete_file(RootDir, FullFilePath, Async, DeleteAfterRename)
     end.
 
-delete_file(RootDir, Filepath, Async) ->
+delete_file(RootDir, Filepath, Async, DeleteAfterRename) ->
     DelFile = filename:join([RootDir,".delete", ?b2l(couch_uuids:random())]),
     case file:rename(Filepath, DelFile) of
-    ok ->
+    ok when DeleteAfterRename ->
         if (Async) ->
             spawn(file, delete, [DelFile]),
             ok;
         true ->
             file:delete(DelFile)
         end;
-    Error ->
-        Error
+    Else ->
+        Else
     end.
 
 rename_file(Original) ->

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -222,8 +222,9 @@ delete(RootDir, Filepath) ->
     delete(RootDir, Filepath, true).
 
 delete(RootDir, FullFilePath, Async) ->
-    RenameOnDelete = config:get_boolean("couchdb", "rename_on_delete", false),
-    case RenameOnDelete of
+    EnableRecovery = config:get_boolean("couchdb",
+        "enable_database_recovery", false),
+    case EnableRecovery of
         true ->
             rename_file(FullFilePath);
         false ->

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -462,7 +462,7 @@ handle_call({delete, DbName, Options}, _From, Server) ->
         couch_db_plugin:on_delete(DbName, Options),
 
         case delete_file(Server#server.root_dir, FullFilepath, Options) of
-        {ok, _} ->
+        ok ->
             couch_event:notify(DbName, deleted),
             {reply, ok, Server2};
         {error, enoent} ->
@@ -542,22 +542,16 @@ db_closed(Server, Options) ->
 delete_file(RootDir, FullFilePath, Options) ->
     Async = not lists:member(sync, Options),
     RenameOnDelete = config:get_boolean("couchdb", "rename_on_delete", false),
-    case {Async, RenameOnDelete} of
-        {_, true} ->
+    case RenameOnDelete of
+        true ->
             rename_on_delete(FullFilePath);
-        {Async, false} ->
-            case couch_file:delete(RootDir, FullFilePath, Async) of
-                ok -> {ok, deleted};
-                Else -> Else
-            end
+        false ->
+            couch_file:delete(RootDir, FullFilePath, Async)
     end.
 
 rename_on_delete(Original) ->
     DeletedFileName = deleted_filename(Original),
-    case file:rename(Original, DeletedFileName) of
-        ok -> {ok, {renamed, DeletedFileName}};
-        Else -> Else
-    end.
+    file:rename(Original, DeletedFileName).
 
 deleted_filename(Original) ->
     {{Y,Mon,D}, {H,Min,S}} = calendar:universal_time(),

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -25,8 +25,6 @@
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
 
--export([delete_file/3]).
-
 -include_lib("couch/include/couch_db.hrl").
 
 -define(MAX_DBS_OPEN, 100).
@@ -461,7 +459,8 @@ handle_call({delete, DbName, Options}, _From, Server) ->
 
         couch_db_plugin:on_delete(DbName, Options),
 
-        case delete_file(Server#server.root_dir, FullFilepath, Options) of
+        Async = not lists:member(sync, Options),
+        case couch_file:delete(Server#server.root_dir, FullFilepath, Async) of
         ok ->
             couch_event:notify(DbName, deleted),
             {reply, ok, Server2};
@@ -538,25 +537,3 @@ db_closed(Server, Options) ->
         false -> Server#server{dbs_open=Server#server.dbs_open - 1};
         true -> Server
     end.
-
-delete_file(RootDir, FullFilePath, Options) ->
-    Async = not lists:member(sync, Options),
-    RenameOnDelete = config:get_boolean("couchdb", "rename_on_delete", false),
-    case RenameOnDelete of
-        true ->
-            rename_on_delete(FullFilePath);
-        false ->
-            couch_file:delete(RootDir, FullFilePath, Async)
-    end.
-
-rename_on_delete(Original) ->
-    DeletedFileName = deleted_filename(Original),
-    file:rename(Original, DeletedFileName).
-
-deleted_filename(Original) ->
-    {{Y,Mon,D}, {H,Min,S}} = calendar:universal_time(),
-    Suffix = lists:flatten(
-        io_lib:format(".~w~2.10.0B~2.10.0B."
-            ++ "~2.10.0B~2.10.0B~2.10.0B.deleted"
-            ++ filename:extension(Original), [Y,Mon,D,H,Min,S])),
-    filename:rootname(Original) ++ Suffix.

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -459,8 +459,8 @@ handle_call({delete, DbName, Options}, _From, Server) ->
 
         couch_db_plugin:on_delete(DbName, Options),
 
-        Async = not lists:member(sync, Options),
-        case couch_file:delete(Server#server.root_dir, FullFilepath, Async) of
+        DelOpt = [{context, delete} | Options],
+        case couch_file:delete(Server#server.root_dir, FullFilepath, DelOpt) of
         ok ->
             couch_event:notify(DbName, deleted),
             {reply, ok, Server2};

--- a/test/couch_file_tests.erl
+++ b/test/couch_file_tests.erl
@@ -295,11 +295,11 @@ delete_test_() ->
             end,
             [
                 fun(Cfg) ->
-                    {"rename_on_delete = false",
+                    {"enable_database_recovery = false",
                     make_delete_test_case(Cfg, false)}
                 end,
                 fun(Cfg) ->
-                    {"rename_on_delete = true",
+                    {"enable_database_recovery = true",
                     make_delete_test_case(Cfg, true)}
                 end
             ]
@@ -307,15 +307,15 @@ delete_test_() ->
     }.
 
 
-make_delete_test_case({RootDir, File}, RenameOnDelete) ->
+make_delete_test_case({RootDir, File}, EnableRecovery) ->
     meck:expect(config, get_boolean, fun
-        ("couchdb", "rename_on_delete", _) -> RenameOnDelete
+        ("couchdb", "enable_database_recovery", _) -> EnableRecovery
     end),
     FileExistsBefore = filelib:is_regular(File),
     couch_file:delete(RootDir, File, false),
     FileExistsAfter = filelib:is_regular(File),
     RenamedFiles = filelib:wildcard(filename:rootname(File) ++ "*.deleted.*"),
-    ExpectRenamedCount = if RenameOnDelete -> 1; true -> 0 end,
+    ExpectRenamedCount = if EnableRecovery -> 1; true -> 0 end,
     [
         ?_assert(FileExistsBefore),
         ?_assertNot(FileExistsAfter),

--- a/test/couch_server_tests.erl
+++ b/test/couch_server_tests.erl
@@ -26,7 +26,7 @@ setup() ->
     Db.
 
 setup(rename) ->
-    config:set("couchdb", "rename_on_delete", "true", false),
+    config:set("couchdb", "enable_database_recovery", "true", false),
     setup();
 setup(_) ->
     setup().
@@ -36,7 +36,7 @@ teardown(Db) ->
     (catch file:delete(Db#db.filepath)).
 
 teardown(rename, Db) ->
-    config:set("couchdb", "rename_on_delete", "false", false),
+    config:set("couchdb", "enable_database_recovery", "false", false),
     teardown(Db);
 teardown(_, Db) ->
     teardown(Db).


### PR DESCRIPTION
All the functions related to file deletion moved into `couch_file` module.

Config option `rename_on_delete` split into two options:

1. Option  `enable_database_recovery`. When set, on user initiated deletion of database renames a database file and the database's views directories in-place with timestamp and "deleted" tag-word suffix, so the database can be recovered if necessary.
2. Option `delete_after_rename`. When set, keeps all the deleted compaction files in ".delete" directory as renamed in random uuids files until the database restart. This allows to postpone deletion of the  compaction files and provides with option of "last minute safe" in case database got corrupted after compaction.