### PR TITLE
Export couch_key_tree:merge/2

### DIFF
--- a/src/couch_key_tree.erl
+++ b/src/couch_key_tree.erl
@@ -60,6 +60,7 @@ map/2,
 map_leafs/2,
 mapfold/3,
 merge/3,
+merge/2,
 remove_leafs/2,
 stem/2
 ]).


### PR DESCRIPTION
This is needed by fabric_doc_open_revs to fix COUCHDB-2863.

COUCHDB-2863