### PR TITLE
Undo our character advancement when we fixup

### DIFF
--- a/priv/couch_js/utf8.c
+++ b/priv/couch_js/utf8.c
@@ -84,6 +84,9 @@ enc_charbuf(const jschar* src, size_t srclen, char* dst, size_t* dstlenp)
                 // Invalid second half of surrogate pair
                 v = (uint32) 0xFFFD;
             }
+            // Undo our character advancement
+            src--;
+            srclen++;
         }
         else
         {


### PR DESCRIPTION
We should undo our character advancement after we finish fixup.

COUCHDB-1425