### PR TITLE
Support create_if_missing option in couch_db:open

### DIFF
--- a/test/couch_db_tests.erl
+++ b/test/couch_db_tests.erl
@@ -39,6 +39,18 @@ create_delete_db_test_()->
         }
     }.
 
+open_db_test_()->
+    {
+        "Database open tests",
+        {
+            setup,
+            fun setup/0, fun test_util:stop_couch/1,
+            fun(_) ->
+                [should_create_db_if_missing()]
+            end
+        }
+    }.
+
 
 should_create_db() ->
     DbName = ?tempdb(),
@@ -97,6 +109,13 @@ should_create_delete_database_continuously() ->
     [{timeout, ?TIMEOUT, {integer_to_list(N) ++ " times",
                            ?_assert(loop(DbName, N))}}
      || N <- [10, 100]].
+
+should_create_db_if_missing() ->
+    DbName = ?tempdb(),
+    {ok, Db} = couch_db:open(DbName, [{create_if_missing, true}]),
+    ok = couch_db:close(Db),
+    {ok, AllDbs} = couch_server:all_databases(),
+    ?_assert(lists:member(DbName, AllDbs)).
 
 loop(_, 0) ->
     true;


### PR DESCRIPTION
Pass `create_if_missing` option to be used in cases like these:

- [fabric_rpc:get_or_create_db/2](https://github.com/apache/couchdb-fabric/blob/master/src/fabric_rpc.erl#L270)
- [mem3_rpc:get_or_create_db/2](https://github.com/apache/couchdb-mem3/pull/21/files#diff-4d22d90c9d6ea299758d2f1262352379R278)
 