### PR TITLE
Fix vhosts oauth tests

### DIFF
--- a/test/couchdb_vhosts_tests.erl
+++ b/test/couchdb_vhosts_tests.erl
@@ -68,6 +68,7 @@ setup_oauth() ->
     config:set("oauth_token_users", "otoksec1", "joe", false),
     config:set("oauth_consumer_secrets", "consec1", "foo", false),
     config:set("oauth_token_secrets", "otoksec1", "foobar", false),
+    config:set("couchdb", "default_security", "everyone", false),
     config:set("couch_httpd_auth", "require_valid_user", "true", false),
 
     ok = config:set(


### PR DESCRIPTION
In eunits the default security is "admin_local" and default security object for it was recently changed. This sets default_security for oauth tests to "everyone", allowing them to pass.