### PR TITLE
Changes tests refactoring

### DIFF
--- a/test/couch_changes_tests.erl
+++ b/test/couch_changes_tests.erl
@@ -55,7 +55,7 @@ teardown({DbName, _}) ->
 
 changes_test_() ->
     {
-        "Changes feeed",
+        "Changes feed",
         {
             setup,
             fun test_util:start_couch/0, fun test_util:stop_couch/1,


### PR DESCRIPTION
In changes_tests, the changes feed consumer is a separate process that presumed to always run successfully and hence hides any abnormal exits, hiding it in `timeout` error. This making debugging of any failing tests rather complicated.

This changes makes consumer into monitored process and re-translates its exception to test suite in format common to eunit's assertion failures.