### PR TITLE
Fix changed feed view filter for clustered access

### DIFF
--- a/src/couch_changes.erl
+++ b/src/couch_changes.erl
@@ -281,7 +281,8 @@ filter(_Db, DocInfo, {design_docs, Style}) ->
         _ ->
             []
     end;
-filter(Db, DocInfo, {view, Style, DDoc, VName}) ->
+filter(Db, DocInfo, {FilterType, Style, DDoc, VName})
+        when FilterType == view; FilterType == fast_view ->
     Docs = open_revs(Db, DocInfo, Style),
     {ok, Passes} = couch_query_servers:filter_view(DDoc, VName, Docs),
     filter_revs(Passes, Docs);


### PR DESCRIPTION
A changes feed can be filtered using view's btree instead of a database btree, a feature known as `fast_view`. This feature not implemented on a clustered interface, however view filter automatically marked as `fast_view` when ddoc has option `seq_indexed` enabled, which leads to a crash of filtered replication.

This change allows `fast_view` filter to be processed as a regular view filter when used on a clustered
interface.

This is a temporary fix for 2.0 release made in consideration of feature freeze. It'll be revisited after the release after `fast_view` will be added into fabric.

COUCHDB-3044