### PR TITLE
Add sleep as a test suite function

### DIFF
--- a/priv/couch_js/help.h
+++ b/priv/couch_js/help.h
@@ -48,6 +48,8 @@ static const char USAGE_TEMPLATE[] =
     "  -V          display version information and exit\n"
     "  -H          enable %s cURL bindings (only avaiable\n"
     "              if package was built with cURL available)\n"
+    "  -T          enable test suite specific functions (these\n"
+    "              should not be enabled for production systems)\n"
     "  -S SIZE     specify that the runtime should allow at\n"
     "              most SIZE bytes of memory to be allocated\n"
     "  -u FILE     path to a .uri file containing the address\n"

--- a/priv/couch_js/util.c
+++ b/priv/couch_js/util.c
@@ -88,6 +88,8 @@ couch_parse_args(int argc, const char* argv[])
             exit(0);
         } else if(strcmp("-H", argv[i]) == 0) {
             args->use_http = 1;
+        } else if(strcmp("-T", argv[i]) == 0) {
+            args->use_test_funs = 1;
         } else if(strcmp("-S", argv[i]) == 0) {
             args->stack_size = atoi(argv[++i]);
             if(args->stack_size <= 0) {

--- a/priv/couch_js/util.h
+++ b/priv/couch_js/util.h
@@ -17,6 +17,7 @@
 
 typedef struct {
     int          use_http;
+    int          use_test_funs;
     int          stack_size;
     const char** scripts;
     const char*  uri_file;


### PR DESCRIPTION
This adds a class of test suite functions that are only available when a
command line switch is passed to couchjs. This so that the JavaScript
test suite has access to some helpful additional functions that aren't
part of the JavaScript language.

This particular change only adds a single `sleep` function which takes a
single argument as the number of milliseconds to sleep.

COUCHDB-3057


---

And a demonstration:


    $ ./bin/couchjs -
    sleep(5);
    ReferenceError: sleep is not defined
    Stacktrace:
    	@-:1
    Failed to execute script.
    $ ./bin/couchjs -T -
    sleep(5000);
    ^D
    davisp@cylinder master $ echo $?
    0
