### PR TITLE
Skip couchdb_os_daemons_tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ priv/couchjs
 priv/couchspawnkillable
 priv/*.exp
 priv/*.lib
+priv/*.dll
+priv/*.exe
 vc120.pdb
 
 .rebar/

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,1 @@
+{eunit_compile_opts, [{platform_define, "win32", 'WINDOWS'}]}.

--- a/test/couchdb_os_daemons_tests.erl
+++ b/test/couchdb_os_daemons_tests.erl
@@ -12,6 +12,12 @@
 
 -module(couchdb_os_daemons_tests).
 
+%% tests are UNIX-specific, will not function under Windows
+-ifdef(WINDOWS).
+-undef(TEST).
+-define(NOTEST, 1).
+-endif.
+
 -include_lib("couch/include/couch_eunit.hrl").
 
 %% keep in sync with couchdb/couch_os_daemons.erl


### PR DESCRIPTION
There are issues launching the .escript files automatically on Windows,
and the .sh files in the test will never run on Windows correctly. In the
interest of speeding along our release I'd like to simply skip these tests
on Windows for now. If launching a daemon completely fails we'll know
via the mrview tests.

Addresses COUCHDB-3040 but does not close it.