### PR TITLE
use couch epi decide

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -1536,12 +1536,8 @@ validate_dbname(DbName) when is_list(DbName) ->
     validate_dbname(?l2b(DbName));
 validate_dbname(DbName) when is_binary(DbName) ->
     Normalized = normalize_dbname(DbName),
-    case couch_db_plugin:validate_dbname(DbName, Normalized) of
-        true ->
-            ok;
-        false ->
-            validate_dbname_int(DbName, Normalized)
-    end.
+    couch_db_plugin:validate_dbname(
+        DbName, Normalized, fun validate_dbname_int/2).
 
 validate_dbname_int(DbName, Normalized) when is_binary(DbName) ->
     case re:run(DbName, ?DBNAME_REGEX, [{capture,none}, dollar_endonly]) of

--- a/test/couch_db_plugin_tests.erl
+++ b/test/couch_db_plugin_tests.erl
@@ -83,30 +83,30 @@ callback_test_() ->
         {
             setup, fun setup/0, fun teardown/1,
             [
-                fun validate_dbname_match/0,
-                fun validate_dbname_no_match/0,
-                fun validate_dbname_throw/0,
-                fun validate_dbname_pass/0,
+                {"validate_dbname_match", fun validate_dbname_match/0},
+                {"validate_dbname_no_match", fun validate_dbname_no_match/0},
+                {"validate_dbname_throw", fun validate_dbname_throw/0},
+                {"validate_dbname_pass", fun validate_dbname_pass/0},
 
-                fun before_doc_update_match/0,
-                fun before_doc_update_no_match/0,
-                fun before_doc_update_throw/0,
+                {"before_doc_update_match", fun before_doc_update_match/0},
+                {"before_doc_update_no_match", fun before_doc_update_no_match/0},
+                {"before_doc_update_throw", fun before_doc_update_throw/0},
 
-                fun after_doc_read_match/0,
-                fun after_doc_read_no_match/0,
-                fun after_doc_read_throw/0,
+                {"after_doc_read_match", fun after_doc_read_match/0},
+                {"after_doc_read_no_match", fun after_doc_read_no_match/0},
+                {"after_doc_read_throw", fun after_doc_read_throw/0},
 
-                fun validate_docid_match/0,
-                fun validate_docid_no_match/0,
-                fun validate_docid_throw/0,
+                {"validate_docid_match", fun validate_docid_match/0},
+                {"validate_docid_no_match", fun validate_docid_no_match/0},
+                {"validate_docid_throw", fun validate_docid_throw/0},
 
-                fun check_is_admin_match/0,
-                fun check_is_admin_no_match/0,
-                fun check_is_admin_throw/0,
+                {"check_is_admin_match", fun check_is_admin_match/0},
+                {"check_is_admin_no_match", fun check_is_admin_no_match/0},
+                {"check_is_admin_throw", fun check_is_admin_throw/0},
 
-                fun on_delete_match/0,
-                fun on_delete_no_match/0,
-                fun on_delete_throw/0
+                {"on_delete_match", fun on_delete_match/0},
+                {"on_delete_no_match", fun on_delete_no_match/0},
+                {"on_delete_throw", fun on_delete_throw/0}
             ]
         }
     }.


### PR DESCRIPTION
It is impossible to make the validation policy more tight from a plugin. This commit would let the plugin to do either tighten up or loosen the validation policy.  

COUCHDB-3066