### PR TITLE
fix validate dbname

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -1519,12 +1519,16 @@ select_lt(V1, _V2) -> V1.
 normalize_dbname(DbName) when is_list(DbName) ->
     normalize_dbname(list_to_binary(DbName));
 normalize_dbname(DbName) when is_binary(DbName) ->
+    mem3:dbname(maybe_remove_extension(DbName)).
+
+maybe_remove_extension(DbName) ->
     case filename:extension(DbName) of
         <<".couch">> ->
-            mem3:dbname(filename:rootname(DbName));
+            filename:rootname(DbName);
         _ ->
-            mem3:dbname(DbName)
+            DbName
     end.
+
 
 -spec dbname_suffix(list() | binary()) -> binary().
 


### PR DESCRIPTION
Fix the case when DbName contains path to db file
In the case when DbName contains the file name we need to remove .couch
extension in order to match ?DBNAME_REGEX.

[COUCHDB-3080](https://issues.apache.org/jira/browse/COUCHDB-3080)