### PR TITLE
Unblock waiting processes during idle process remove

### DIFF
--- a/src/couch_proc_manager.erl
+++ b/src/couch_proc_manager.erl
@@ -447,23 +447,13 @@ return_proc(#state{} = State, #proc_int{} = ProcInt) ->
                 true = ets:update_element(?PROCS, Pid, [
                     {#proc_int.client, undefined}
                 ]),
-                maybe_assign_proc(State, ProcInt)
+                State
         end;
     false ->
         remove_proc(State, ProcInt)
     end,
     flush_waiters(NewState, Lang).
 
-maybe_assign_proc(#state{} = State, ProcInt) ->
-    #proc_int{lang = Lang} = ProcInt,
-    case get_waiting_client(Lang) of
-        #client{from = From} = Client ->
-            Proc = assign_proc(Client, ProcInt#proc_int{client=undefined}),
-            gen_server:reply(From, {ok, Proc, State#state.config}),
-            State;
-        undefined ->
-            State
-    end.
 
 remove_proc(State, #proc_int{}=Proc) ->
     ets:delete(?PROCS, Proc#proc_int.pid),


### PR DESCRIPTION
To clarify the description of the problem here is some terminology used in the process manager:

- idle process - a running os process with no associated query server's client
- assign process - set client (monitoring ref) to idle os process
- teach ddoc - an initialization step that stores ddoc in couchjs cache
- return process - mark process as an idle by setting its client (monitoring reference) to `undefined`
- remove process - stop os process and decrease process counter
- soft limit - number of os processes as per proc counter after which process manager starts to remove idle processes
- hard limit - number of os processes as per proc counter after which process manager stops to spawn new processes. new requests placed in a waiting list
- flush waiters - walk waiting list and start new process if process count below hard limit

### Problem

Process manager flushes waiters only when it catches os process 'EXIT' or when process returned. Since it unlinks the processes before removing them, there are no waiters flush during soft limit trimming. That means once request got into waiting list its only chance to be flushed is for idle process count go over soft limit, then no new request to come after that and wait for some of the remaining client to return process. In sense waiters have the lowest priority in assigning, so we can have a situation when there are number of idle processes, but the waiters are still blocked.

Commit that added `maybe_assign_proc/2` during return process tried to tackle it by directly assigning fresh idle process to one of the waiters, but since it doesn't ran process through teach ddoc this leads to crash with `query_protocol_error`.

### Solution

I suggest to flash waiters on remove process instead of return process. That way waiters will always be getting first free process, will not be waiting for other client to return process and will not get superseded by new requests coming in-between.

COUCHDB-3095