### PR TITLE
Simplify proc manager by moving assignment logic in one place

### DIFF
--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -22,7 +22,7 @@
 -export([with_ddoc_proc/2, proc_prompt/2, ddoc_prompt/3, ddoc_proc_prompt/3, json_doc/1]).
 
 % For 210-os-proc-pool.t
--export([get_os_process/1, ret_os_process/1]).
+-export([get_os_process/1, get_ddoc_process/2, ret_os_process/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 


### PR DESCRIPTION
This changes how proc manager handles proc assignment. Instead of doing this in three different places: `get_proc` call handler, `return_proc/2` with `maybe_assign_proc` and `flush_waiters/2`, proc manager now just places all the incoming requests in the waiting queue and then flushes it. 

As a result all the logic kept in one place which makes it more obvious that we are treating proc management as a processing of a single FIFO queue with "soft" and "hard" upper limits.

Consequently this is fixing a bug in `maybe_assign_proc` where it was possible to assign a client a process that wasn't aware of it.

COUCHDB-3095