### PR TITLE
Fix Windows version string determination

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -36,7 +36,7 @@ Version = case os:getenv("COUCHDB_VERSION") of
     false ->
         string:strip(os:cmd("git describe --always"), right, $\n);
     Version0 ->
-        Version0
+        string:strip(Version0, right)
 end,
 
 CouchConfig = case filelib:is_file(os:getenv("COUCHDB_CONFIG")) of

--- a/src/couch.app.src.script
+++ b/src/couch.app.src.script
@@ -15,7 +15,7 @@ Version = case os:getenv("COUCHDB_VERSION") of
     false ->
         string:strip(os:cmd("git describe --always"), right, $\n);
     Version0 ->
-        Version0
+        string:strip(Version0, right)
 end,
 
 


### PR DESCRIPTION
For some reason, the COUCHDB_VERSION string on Windows is getting
suffixed whitespace. We fix this by string:strip(Version0, right) on the
variable before use.