### PR TITLE
Define couch version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,0 @@
-{erl_opts, [{platform_define, "win32", 'WINDOWS'}]}.
-{eunit_compile_opts, [{platform_define, "win32", 'WINDOWS'}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -135,7 +135,8 @@ end,
 AddConfig = [
     {port_specs, PortSpecs},
     {erl_opts, [
-        {platform_define, "win32", 'WINDOWS'}
+        {platform_define, "win32", 'WINDOWS'},
+        {d, 'COUCHDB_VERSION', Version}
     ]},
     {eunit_compile_opts, [{platform_define, "win32", 'WINDOWS'}]}
 ].

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -132,7 +132,13 @@ PortSpecs = case os:type() of
         BaseSpecs
 end,
 
-AddConfig = [{port_specs, PortSpecs}].
+AddConfig = [
+    {port_specs, PortSpecs},
+    {erl_opts, [
+        {platform_define, "win32", 'WINDOWS'}
+    ]},
+    {eunit_compile_opts, [{platform_define, "win32", 'WINDOWS'}]}
+].
 
 lists:foldl(fun({K, V}, CfgAcc) ->
     lists:keystore(K, 1, CfgAcc, {K, V})

--- a/src/couch.app.src
+++ b/src/couch.app.src
@@ -10,18 +10,9 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-%% cut-paste from rebar.config.script. dedupe somehow later.
-Version = case os:getenv("COUCHDB_VERSION") of
-    false ->
-        string:strip(os:cmd("git describe --always"), right, $\n);
-    Version0 ->
-        Version0
-end,
-
-
 {application, couch, [
     {description, "Apache CouchDB"},
-    {vsn, Version},
+    {vsn, {cmd, "echo $COUCHDB_VERSION"}},
     {registered, [
         couch_db_update,
         couch_db_update_notifier_sup,

--- a/src/couch.app.src
+++ b/src/couch.app.src
@@ -12,7 +12,7 @@
 
 {application, couch, [
     {description, "Apache CouchDB"},
-    {vsn, {cmd, "echo $COUCHDB_VERSION"}},
+    {vsn, git},
     {registered, [
         couch_db_update,
         couch_db_update_notifier_sup,

--- a/src/couch.app.src.script
+++ b/src/couch.app.src.script
@@ -15,7 +15,7 @@ Version = case os:getenv("COUCHDB_VERSION") of
     false ->
         string:strip(os:cmd("git describe --always"), right, $\n);
     Version0 ->
-        string:strip(Version0, right)
+        Version0
 end,
 
 

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -45,10 +45,7 @@ dev_start() ->
     couch:start().
 
 get_version() ->
-    case application:get_key(couch, vsn) of
-        {ok, Version} -> Version;
-        undefined -> "0.0.0"
-    end.
+    ?COUCHDB_VERSION. %% Defined in rebar.config.script
 get_version(short) ->
   %% strip git hash from version string
   [Version|_Rest] = string:tokens(get_version(), "+"),


### PR DESCRIPTION
This changes the way we set the value for `couch_server:get_version`. The `get_version` function is used in:
- version key of welcome message
- Server header returned in every response

This implementation defines a COUCH_VERSION macro. This is done in order to ensure that we keep using `{vsn, git},` in `src/couch.app.src`. There is also additional benefit of using the macro. It saves us an access to ets table. ETS is used for `application:get_key`. Since get_version is called for every request the saving should be significant. This would improve on previous analysis and work done by @robertkowalski [here](https://github.com/robertkowalski/kowalski.gd/blob/master/_posts/2016-02-10-high-performance-erlang-finding-bottlenecks-couchdb-1.md). 
