### PR TITLE
Add max_document_size checking for multipart PUT requests

### DIFF
--- a/src/couch_httpd.erl
+++ b/src/couch_httpd.erl
@@ -33,6 +33,8 @@
 -export([http_1_0_keep_alive/2]).
 -export([validate_host/1]).
 -export([validate_bind_address/1]).
+-export([check_max_request_length/1]).
+
 
 -define(HANDLER_NAME_IN_MODULE_POS, 6).
 
@@ -445,6 +447,18 @@ validate_ctype(Req, Ctype) ->
             throw({bad_ctype, "Content-Type must be "++Ctype})
         end
     end.
+
+
+check_max_request_length(Req) ->
+    Len = list_to_integer(header_value(Req, "Content-Length", "0")),
+    MaxLen = config:get_integer("couchdb", "max_document_size", 4294967296),
+    case Len > MaxLen of
+        true ->
+            exit({body_too_large, Len});
+        false ->
+            ok
+    end.
+
 
 % Utilities
 

--- a/src/couch_httpd_db.erl
+++ b/src/couch_httpd_db.erl
@@ -583,6 +583,7 @@ db_doc_req(#httpd{method='PUT'}=Req, Db, DocId) ->
 
     case couch_util:to_list(couch_httpd:header_value(Req, "Content-Type")) of
     ("multipart/related;" ++ _) = ContentType ->
+        couch_chttpd:check_max_request_length(Req),
         {ok, Doc0, WaitFun, Parser} = couch_doc:doc_from_multi_part_stream(
             ContentType, fun() -> receive_request_data(Req) end),
         Doc = couch_doc_from_req(Req, DocId, Doc0),


### PR DESCRIPTION
Previously multipart/related PUT requests didn't check maximum request sizes.

This commit checks content-length and compares that with the maximum.

This means keeping the current "semantics" of max_document_size which actually
means "max request size". But this makes the check more efficient and can
be done earlier in request processing time.

Jira: COUCHDB-3174