### PR TITLE
Fix CouchJS character replacement

### DIFF
--- a/priv/couch_js/utf8.c
+++ b/priv/couch_js/utf8.c
@@ -83,10 +83,10 @@ enc_charbuf(const jschar* src, size_t srclen, char* dst, size_t* dstlenp)
             {
                 // Invalid second half of surrogate pair
                 v = (uint32) 0xFFFD;
+                // Undo our character advancement
+                src--;
+                srclen++;
             }
-            // Undo our character advancement
-            src--;
-            srclen++;
         }
         else
         {


### PR DESCRIPTION
This was a bad backport from an old bug. We accidentally backed up when
looking at the second half of a surrogate pair. Instead the backup
should only happen when we see a low half of a surrogate pair with no
preceding high half.

COUCHDB-3173