### PR TITLE
Add couch_debug:opened_files_by_regexp/1

### DIFF
--- a/src/couch_debug.erl
+++ b/src/couch_debug.erl
@@ -12,7 +12,10 @@
 
 -module(couch_debug).
 
--export([opened_files/0]).
+-export([
+    opened_files/0,
+    opened_files_by_regexp/1
+]).
 
 -spec opened_files() ->
     [{port(), CouchFilePid :: pid(), Fd :: pid() | tuple(), FilePath :: string()}].
@@ -31,3 +34,11 @@ couch_file_port_info(Port) ->
         undefined ->
             undefined
     end.
+
+-spec opened_files_by_regexp(FileRegExp :: iodata()) ->
+    [{port(), CouchFilePid :: pid(), Fd :: pid() | tuple(), FilePath :: string()}].
+opened_files_by_regexp(FileRegExp) ->
+    {ok, RegExp} = re:compile(FileRegExp),
+    lists:filter(fun({_Port, _Pid, _Fd, Path}) ->
+        re:run(Path, RegExp) =/= nomatch
+    end, couch_debug:opened_files()).

--- a/src/couch_debug.erl
+++ b/src/couch_debug.erl
@@ -14,7 +14,8 @@
 
 -export([
     opened_files/0,
-    opened_files_by_regexp/1
+    opened_files_by_regexp/1,
+    opened_files_contains/1
 ]).
 
 -spec opened_files() ->
@@ -41,4 +42,11 @@ opened_files_by_regexp(FileRegExp) ->
     {ok, RegExp} = re:compile(FileRegExp),
     lists:filter(fun({_Port, _Pid, _Fd, Path}) ->
         re:run(Path, RegExp) =/= nomatch
+    end, couch_debug:opened_files()).
+
+-spec opened_files_contains(FileNameFragment :: iodata()) ->
+    [{port(), CouchFilePid :: pid(), Fd :: pid() | tuple(), FilePath :: string()}].
+opened_files_contains(FileNameFragment) ->
+    lists:filter(fun({_Port, _Pid, _Fd, Path}) ->
+        string:str(Path, FileNameFragment) > 0
     end, couch_debug:opened_files()).


### PR DESCRIPTION
couch_debug:opened_files_by_regexp is an efficient way to find out list
of file descriptors or couch_file processes which path matches given
regexp