### PR TITLE
Add test for filter _changes by filters function

### DIFF
--- a/test/couch_changes_tests.erl
+++ b/test/couch_changes_tests.erl
@@ -863,7 +863,7 @@ spawn_consumer(DbName, ChangesArgs0, Req) ->
             FeedFun({Callback, []})
         catch
             throw:{stop, _} -> ok;
-            _:Error -> Error
+            _:Error -> exit(Error)
         after
             couch_db:close(Db)
         end


### PR DESCRIPTION
This adds tests for basic filtering of _changes feed by "filters" function both for filtering by doc attributes and by passed in request object. This is complimentary to apache/couchdb-chttpd#150

The test also was refactored to reduce code duplication and name variables consistently.

COUCHDB-3233