### PR TITLE
Implement couch_file:format_status to log filepath

### DIFF
--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -47,7 +47,7 @@
 -export([delete/2, delete/3, nuke_dir/2, init_delete_dir/1]).
 
 % gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2, code_change/3, format_status/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 %% helper functions
@@ -528,6 +528,9 @@ handle_info({'EXIT', _, normal}, Fd) ->
 handle_info({'EXIT', _, Reason}, Fd) ->
     {stop, Reason, Fd}.
 
+format_status(_Opt, [PDict, #file{} = File]) ->
+    {_Fd, FilePath} = couch_util:get_value(couch_file_fd, PDict),
+    [{data, [{"State", File}, {"InitialFilePath", FilePath}]}].
 
 find_header(Fd, Block) ->
     case (catch load_header(Fd, Block)) of


### PR DESCRIPTION
Erlang OTP logs the fact when gen_server behavior crashes. However in case of `couch_file` the filename is not part of the state. So it is quite hard to figure out what happened given the current log entry format. This PR adds information about filepath to the log entry. Keep in mind though that the filepath value is captured on couch_file:start_link. It is not representing the current file name if file is renamed or moved. 