### PR TITLE
Make couchjs -S option take effect

### DIFF
--- a/priv/couch_js/main.c
+++ b/priv/couch_js/main.c
@@ -387,11 +387,11 @@ main(int argc, const char* argv[])
 
     couch_args* args = couch_parse_args(argc, argv);
 
-    rt = JS_NewRuntime(64L * 1024L * 1024L);
+    rt = JS_NewRuntime(args->stack_size);
     if(rt == NULL)
         return 1;
 
-    cx = JS_NewContext(rt, args->stack_size);
+    cx = JS_NewContext(rt, 8L * 1024L);
     if(cx == NULL)
         return 1;
 


### PR DESCRIPTION
Previously it was used to set JS context's stack chunk size.

Instead, to be effective it should set max GC size of the runtime.

Stack chunk size was set to the recommended value: 8K

Reference:

https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_reference/JS_NewContext

COUCHDB-3245