### PR TITLE
Improve errors on invalid "count" parameter in /_uuids

### DIFF
--- a/src/couch_httpd_misc_handlers.erl
+++ b/src/couch_httpd_misc_handlers.erl
@@ -129,7 +129,7 @@ handle_uuids_req(#httpd{method='GET'}=Req) ->
     Max = list_to_integer(config:get("uuids","max_count","1000")),
     Count = try list_to_integer(couch_httpd:qs_value(Req, "count", "1")) of
         N when N > Max ->
-            throw({forbidden, <<"count parameter too large">>});
+            throw({bad_request, <<"count parameter too large">>});
         N when N < 0 ->
             throw({bad_request, <<"count must be a positive integer">>});
         N -> N

--- a/src/couch_httpd_misc_handlers.erl
+++ b/src/couch_httpd_misc_handlers.erl
@@ -130,10 +130,12 @@ handle_uuids_req(#httpd{method='GET'}=Req) ->
     Count = try list_to_integer(couch_httpd:qs_value(Req, "count", "1")) of
         N when N > Max ->
             throw({forbidden, <<"count parameter too large">>});
+        N when N < 0 ->
+            throw({bad_request, <<"count must be a positive integer">>});
         N -> N
     catch
         error:badarg ->
-            throw({bad_request, <<"count parameter is not an integer">>})
+            throw({bad_request, <<"count must be a positive integer">>})
     end,
     UUIDs = [couch_uuids:new() || _ <- lists:seq(1, Count)],
     Etag = couch_httpd:make_etag(UUIDs),


### PR DESCRIPTION
Added validation on "count" parameter to be positive and changed return code for "count" exceeding maximum from "Forbidden" to "Bad Request"

COUCHDB-3273