### PR TITLE
Don't crash on unexpected validation's error type

### DIFF
--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -289,6 +289,8 @@ validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
             throw({forbidden, Message});
         {[{<<"unauthorized">>, Message}]} ->
             throw({unauthorized, Message});
+        {[{_, Message}]} ->
+            throw({unknown_error, Message});
         Message when is_binary(Message) ->
             throw({unknown_error, Message})
     end.


### PR DESCRIPTION
Validation function can throw JSON with error type different than forbidden or unauthorized.

This patch makes couch return unknown_error instead of crashing query server.

COUCHDB-3286
