### PR TITLE
Couchdb 3298 improve couch btree chunkify

### DIFF
--- a/src/couch_btree.erl
+++ b/src/couch_btree.erl
@@ -342,11 +342,9 @@ complete_root(Bt, KPs) ->
 % it's probably really inefficient.
 
 chunkify(InList) ->
-    BaseChunkSize = get_chunk_size(),
+    ChunkThreshold = get_chunk_size(),
     case ?term_size(InList) of
-    Size when Size > BaseChunkSize ->
-        NumberOfChunksLikely = ((Size div BaseChunkSize) + 1),
-        ChunkThreshold = Size div NumberOfChunksLikely,
+    Size when Size > ChunkThreshold ->
         chunkify(InList, ChunkThreshold, [], 0, []);
     _Else ->
         [InList]

--- a/src/couch_btree.erl
+++ b/src/couch_btree.erl
@@ -352,6 +352,9 @@ chunkify(InList) ->
 
 chunkify([], _ChunkThreshold, [], 0, OutputChunks) ->
     lists:reverse(OutputChunks);
+chunkify([], _ChunkThreshold, [Item], _OutListSize, [PrevChunk | RestChunks]) ->
+    NewPrevChunk = PrevChunk ++ [Item],
+    lists:reverse(RestChunks, [NewPrevChunk]);
 chunkify([], _ChunkThreshold, OutList, _OutListSize, OutputChunks) ->
     lists:reverse([lists:reverse(OutList) | OutputChunks]);
 chunkify([InElement | RestInList], ChunkThreshold, OutList, OutListSize, OutputChunks) ->


### PR DESCRIPTION
This PR adds two slight tweaks to the couch_btree:chunkify/1 function.

First, rather than create a larger number of evenly sized chunks it will create as few chunks under the configurable chunk threshold as possible with the final chunk possibly being less full than average.

Second, it prevents the return of a final chunk that has a single key. In some pathological cases we could end up with a branch of the tree that had multiple levels of nodes that had a single key. This is caused when a reduce function is returning values that are larger than the chunk threshold.