### PR TITLE
Fix `badarith` error in couch_db:get_db_info call

### DIFF
--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -391,7 +391,7 @@ active_size(#db{}=Db, #size_info{}=SI) ->
         case couch_btree:size(T) of
             _ when Acc == null ->
                 null;
-            undefined ->
+            nil ->
                 null;
             Size ->
                 Acc + Size


### PR DESCRIPTION
When folding we account for a previous `null`, `undefined`, or a number. However
btree:size/1 returns 0, `nil` or a number.

Switched `undefined` to `nil`. Couldn't find where btree:size would ever return
`undefined`, it seems we meant to use `nil` instead.

COUCHDB-3316