### PR TITLE
Rename max_document_size to max_http_request_size

### DIFF
--- a/src/couch_httpd.erl
+++ b/src/couch_httpd.erl
@@ -451,7 +451,7 @@ validate_ctype(Req, Ctype) ->
 
 check_max_request_length(Req) ->
     Len = list_to_integer(header_value(Req, "Content-Length", "0")),
-    MaxLen = config:get_integer("couchdb", "max_document_size", 4294967296),
+    MaxLen = config:get_integer("httpd", "max_http_request_size", 4294967296),
     case Len > MaxLen of
         true ->
             exit({body_too_large, Len});
@@ -576,8 +576,7 @@ body_length(#httpd{mochi_req=MochiReq}) ->
     MochiReq:get(body_length).
 
 body(#httpd{mochi_req=MochiReq, req_body=undefined}) ->
-    MaxSize = list_to_integer(
-        config:get("couchdb", "max_document_size", "4294967296")),
+    MaxSize = config:get_integer("httpd", "max_http_request_size", 4294967296),
     MochiReq:recv_body(MaxSize);
 body(#httpd{req_body=ReqBody}) ->
     ReqBody.

--- a/src/couch_httpd_external.erl
+++ b/src/couch_httpd_external.erl
@@ -63,8 +63,8 @@ json_req_obj(#httpd{mochi_req=Req,
             }, Db, DocId) ->
     Body = case ReqBody of
         undefined ->
-            MaxSize = list_to_integer(
-                config:get("couchdb", "max_document_size", "4294967296")),
+            MaxSize = config:get_integer("httpd", "max_http_request_size",
+                4294967296),
             Req:recv_body(MaxSize);
         Else -> Else
     end,


### PR DESCRIPTION
`max_document_size` is implemented as `max_http_request_size`. There was no
real check for document size. In some cases the implementation was close enough
of a proxy (PUT-ing and GET-ing single docs), but in some edge cases, like
_bulk_docs requests the discrepancy between request size and document size
could be rather large.

The section was changed accordingly from `couchdb` to `httpd`. `httpd` was
chosen as it applies to both clustered as well as local interface.

There is a parallel effort to implement an actual max_document_size check. The
set of commit should be merged close enough together to allow for a backwards
compatible transition.

COUCHDB-2992