### PR TITLE
Fix initial accumulator value for builtin_sum_rows

### DIFF
--- a/src/couch_query_servers.erl
+++ b/src/couch_query_servers.erl
@@ -142,13 +142,13 @@ os_rereduce(Lang, OsRedSrcs, KVs) ->
 builtin_reduce(_Re, [], _KVs, Acc) ->
     {ok, lists:reverse(Acc)};
 builtin_reduce(Re, [<<"_sum",_/binary>>|BuiltinReds], KVs, Acc) ->
-    Sum = builtin_sum_rows(KVs, []),
+    Sum = builtin_sum_rows(KVs, 0),
     builtin_reduce(Re, BuiltinReds, KVs, [Sum|Acc]);
 builtin_reduce(reduce, [<<"_count",_/binary>>|BuiltinReds], KVs, Acc) ->
     Count = length(KVs),
     builtin_reduce(reduce, BuiltinReds, KVs, [Count|Acc]);
 builtin_reduce(rereduce, [<<"_count",_/binary>>|BuiltinReds], KVs, Acc) ->
-    Count = builtin_sum_rows(KVs, []),
+    Count = builtin_sum_rows(KVs, 0),
     builtin_reduce(rereduce, BuiltinReds, KVs, [Count|Acc]);
 builtin_reduce(Re, [<<"_stats",_/binary>>|BuiltinReds], KVs, Acc) ->
     Stats = builtin_stats(Re, KVs),


### PR DESCRIPTION
This a fixup for https://github.com/apache/couchdb-couch/pull/229.
The initial value for accumulator suppose to be 0. Since the result of
sum and count is integer. The problem was discovered by dialyzer.

COUCHDB-3305