### PR TITLE
Allow limiting maximum document body size

### DIFF
--- a/src/couch_doc.erl
+++ b/src/couch_doc.erl
@@ -424,7 +424,7 @@ doc_from_multi_part_stream(ContentType, DataFun, Ref) ->
     {{started_open_doc_revs, NewRef}, Parser, _ParserRef} ->
         restart_open_doc_revs(Parser, Ref, NewRef);
     {{doc_bytes, Ref, DocBytes}, Parser, ParserRef} ->
-        Doc = from_json_obj(?JSON_DECODE(DocBytes)),
+        Doc = from_json_obj_validate(?JSON_DECODE(DocBytes)),
         erlang:put(mochiweb_request_recv, true),
         % we'll send the Parser process ID to the remote nodes so they can
         % retrieve their own copies of the attachment data

--- a/src/couch_httpd_db.erl
+++ b/src/couch_httpd_db.erl
@@ -256,7 +256,7 @@ db_req(#httpd{method='GET',path_parts=[_DbName]}=Req, Db) ->
 
 db_req(#httpd{method='POST',path_parts=[_DbName]}=Req, Db) ->
     couch_httpd:validate_ctype(Req, "application/json"),
-    Doc = couch_doc:from_json_obj(couch_httpd:json_body(Req)),
+    Doc = couch_doc:from_json_obj_validate(couch_httpd:json_body(Req)),
     validate_attachment_names(Doc),
     Doc2 = case Doc#doc.id of
         <<"">> ->
@@ -319,7 +319,7 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_bulk_docs">>]}=Req, Db) ->
         true ->
             Docs = lists:map(
                 fun({ObjProps} = JsonObj) ->
-                    Doc = couch_doc:from_json_obj(JsonObj),
+                    Doc = couch_doc:from_json_obj_validate(JsonObj),
                     validate_attachment_names(Doc),
                     Id = case Doc#doc.id of
                         <<>> -> couch_uuids:new();
@@ -353,7 +353,7 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_bulk_docs">>]}=Req, Db) ->
             end;
         false ->
             Docs = lists:map(fun(JsonObj) ->
-                    Doc = couch_doc:from_json_obj(JsonObj),
+                    Doc = couch_doc:from_json_obj_validate(JsonObj),
                     validate_attachment_names(Doc),
                     Doc
                 end, DocsArray),
@@ -809,7 +809,7 @@ couch_doc_from_req(Req, DocId, #doc{revs=Revs}=Doc) ->
     end,
     Doc#doc{id=DocId, revs=Revs2};
 couch_doc_from_req(Req, DocId, Json) ->
-    couch_doc_from_req(Req, DocId, couch_doc:from_json_obj(Json)).
+    couch_doc_from_req(Req, DocId, couch_doc:from_json_obj_validate(Json)).
 
 % Useful for debugging
 % couch_doc_open(Db, DocId) ->

--- a/test/couch_doc_json_tests.erl
+++ b/test/couch_doc_json_tests.erl
@@ -38,6 +38,8 @@ mock(couch_log) ->
     ok;
 mock(config) ->
     meck:new(config, [passthrough]),
+    meck:expect(config, get_integer,
+        fun("couchdb", "max_document_size", 4294967296) -> 1024 end),
     meck:expect(config, get, fun(_, _) -> undefined end),
     meck:expect(config, get, fun(_, _, Default) -> Default end),
     ok.
@@ -230,10 +232,23 @@ from_json_error_cases() ->
             {[{<<"_something">>, 5}]},
             {doc_validation, <<"Bad special document member: _something">>},
             "Underscore prefix fields are reserved."
+        },
+        {
+            fun() ->
+                {[
+                    {<<"_id">>, <<"large_doc">>},
+                    {<<"x">> , << <<"x">> || _ <- lists:seq(1,1025) >>}
+                ]}
+            end,
+            {request_entity_too_large, <<"large_doc">>},
+            "Document too large."
         }
     ],
 
     lists:map(fun
+        ({Fun, Expect, Msg}) when is_function(Fun, 0) ->
+            Error = (catch couch_doc:from_json_obj(Fun())),
+            {Msg, ?_assertMatch(Expect, Error)};
         ({EJson, Expect, Msg}) ->
             Error = (catch couch_doc:from_json_obj(EJson)),
             {Msg, ?_assertMatch(Expect, Error)};

--- a/test/couch_doc_json_tests.erl
+++ b/test/couch_doc_json_tests.erl
@@ -167,7 +167,7 @@ from_json_success_cases() ->
     ],
     lists:map(
         fun({EJson, Expect, Msg}) ->
-            {Msg, ?_assertMatch(Expect, couch_doc:from_json_obj(EJson))}
+            {Msg, ?_assertMatch(Expect, couch_doc:from_json_obj_validate(EJson))}
         end,
         Cases).
 
@@ -247,14 +247,14 @@ from_json_error_cases() ->
 
     lists:map(fun
         ({Fun, Expect, Msg}) when is_function(Fun, 0) ->
-            Error = (catch couch_doc:from_json_obj(Fun())),
+            Error = (catch couch_doc:from_json_obj_validate(Fun())),
             {Msg, ?_assertMatch(Expect, Error)};
         ({EJson, Expect, Msg}) ->
-            Error = (catch couch_doc:from_json_obj(EJson)),
+            Error = (catch couch_doc:from_json_obj_validate(EJson)),
             {Msg, ?_assertMatch(Expect, Error)};
         ({EJson, Msg}) ->
             try
-                couch_doc:from_json_obj(EJson),
+                couch_doc:from_json_obj_validate(EJson),
                 {"Conversion failed to raise an exception", ?_assert(false)}
             catch
                 _:_ -> {Msg, ?_assert(true)}


### PR DESCRIPTION
Configuration is via the `couchdb.max_document_size`. In the past that
was implemented as a maximum http request body size and this finally implements
it by actually checking a document's body size.

COUCHDB-2992