### PR TITLE
Add sys_dbs to the LRU

### DIFF
--- a/src/couch_db_updater.erl
+++ b/src/couch_db_updater.erl
@@ -61,12 +61,7 @@ init({DbName, Filepath, Fd, Options}) ->
         end
     end,
     Db = init_db(DbName, Filepath, Fd, Header, Options),
-    case lists:member(sys_db, Options) of
-        false ->
-            couch_stats_process_tracker:track([couchdb, open_databases]);
-        true ->
-            ok
-    end,
+    couch_stats_process_tracker:track([couchdb, open_databases]),
     % we don't load validation funs here because the fabric query is liable to
     % race conditions.  Instead see couch_db:validate_doc_update, which loads
     % them lazily

--- a/src/couch_file.erl
+++ b/src/couch_file.erl
@@ -362,7 +362,7 @@ init({Filepath, Options, ReturnPid, Ref}) ->
                     {ok, 0} = file:position(Fd, 0),
                     ok = file:truncate(Fd),
                     ok = file:sync(Fd),
-                    maybe_track_open_os_files(Options),
+                    couch_stats_process_tracker:track([couchdb, open_os_files]),
                     erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
                     {ok, #file{fd=Fd, is_sys=IsSys, pread_limit=Limit}};
                 false ->
@@ -370,7 +370,7 @@ init({Filepath, Options, ReturnPid, Ref}) ->
                     init_status_error(ReturnPid, Ref, {error, eexist})
                 end;
             false ->
-                maybe_track_open_os_files(Options),
+                couch_stats_process_tracker:track([couchdb, open_os_files]),
                 erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
                 {ok, #file{fd=Fd, is_sys=IsSys, pread_limit=Limit}}
             end;
@@ -385,7 +385,7 @@ init({Filepath, Options, ReturnPid, Ref}) ->
             %% Save Fd in process dictionary for debugging purposes
             put(couch_file_fd, {Fd, Filepath}),
             ok = file:close(Fd_Read),
-            maybe_track_open_os_files(Options),
+            couch_stats_process_tracker:track([couchdb, open_os_files]),
             {ok, Eof} = file:position(Fd, eof),
             erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
             {ok, #file{fd=Fd, eof=Eof, is_sys=IsSys, pread_limit=Limit}};
@@ -400,14 +400,6 @@ file_open_options(Options) ->
         [];
     false ->
         [append]
-    end.
-
-maybe_track_open_os_files(Options) ->
-    case not lists:member(sys_db, Options) of
-        true ->
-            couch_stats_process_tracker:track([couchdb, open_os_files]);
-        false ->
-            ok
     end.
 
 terminate(_Reason, #file{fd = nil}) ->
@@ -676,13 +668,7 @@ split_iolist([Byte | Rest], SplitAt, BeginAcc) when is_integer(Byte) ->
     split_iolist(Rest, SplitAt - 1, [Byte | BeginAcc]).
 
 
-% System dbs aren't monitored by couch_stats_process_tracker
-is_idle(#file{is_sys=true}) ->
-    case process_info(self(), monitored_by) of
-        {monitored_by, []} -> true;
-        _ -> false
-    end;
-is_idle(#file{is_sys=false}) ->
+is_idle(#file{}) ->
     Tracker = whereis(couch_stats_process_tracker),
     case process_info(self(), monitored_by) of
         {monitored_by, []} -> true;

--- a/src/couch_server.erl
+++ b/src/couch_server.erl
@@ -73,8 +73,8 @@ sup_start_link() ->
 open(DbName, Options0) ->
     Ctx = couch_util:get_value(user_ctx, Options0, #user_ctx{}),
     case ets:lookup(couch_dbs, DbName) of
-    [#db{fd=Fd, fd_monitor=Lock, options=Options} = Db] when Lock =/= locked ->
-        update_lru(DbName, Options),
+    [#db{fd=Fd, fd_monitor=Lock} = Db] when Lock =/= locked ->
+        update_lru(DbName),
         {ok, Db#db{user_ctx=Ctx, fd_monitor=erlang:monitor(process,Fd)}};
     _ ->
         Options = maybe_add_sys_db_callbacks(DbName, Options0),
@@ -91,11 +91,8 @@ open(DbName, Options0) ->
         end
     end.
 
-update_lru(DbName, Options) ->
-    case lists:member(sys_db, Options) of
-        false -> gen_server:cast(couch_server, {update_lru, DbName});
-        true -> ok
-    end.
+update_lru(DbName) ->
+    gen_server:cast(couch_server, {update_lru, DbName}).
 
 close_lru() ->
     gen_server:call(couch_server, close_lru).
@@ -271,20 +268,15 @@ all_databases(Fun, Acc0) ->
     {ok, FinalAcc}.
 
 
-make_room(Server, Options) ->
-    case lists:member(sys_db, Options) of
-        false -> maybe_close_lru_db(Server);
-        true -> {ok, Server}
-    end.
-
 maybe_close_lru_db(#server{dbs_open=NumOpen, max_dbs_open=MaxOpen}=Server)
         when NumOpen < MaxOpen ->
     {ok, Server};
 maybe_close_lru_db(#server{lru=Lru}=Server) ->
-    try
-        {ok, db_closed(Server#server{lru = couch_lru:close(Lru)}, [])}
-    catch error:all_dbs_active ->
-        {error, all_dbs_active}
+    case couch_lru:close(Lru) of
+        false ->
+            {ok, Server};
+        {true, NewLru} ->
+            maybe_close_lru_db(db_closed(Server#server{lru = NewLru}))
     end.
 
 open_async(Server, From, DbName, Filepath, Options) ->
@@ -316,13 +308,14 @@ open_async(Server, From, DbName, Filepath, Options) ->
         options = Options
     }),
     true = ets:insert(couch_dbs_pid_to_name, {Opener, DbName}),
-    db_opened(Server, Options).
+    db_opened(Server).
 
 handle_call(close_lru, _From, #server{lru=Lru} = Server) ->
-    try
-        {reply, ok, db_closed(Server#server{lru = couch_lru:close(Lru)}, [])}
-    catch error:all_dbs_active ->
-        {reply, {error, all_dbs_active}, Server}
+    case couch_lru:close(Lru) of
+        false ->
+            {reply, ok, Server};
+        {true, NewLru} ->
+            {reply, ok, db_closed(Server#server{lru = NewLru})}
     end;
 handle_call(open_dbs_count, _From, Server) ->
     {reply, Server#server.dbs_open, Server};
@@ -355,12 +348,7 @@ handle_call({open_result, T0, DbName, {ok, Db}}, {FromPid, _Tag}, Server) ->
             end,
             true = ets:insert(couch_dbs, Db),
             true = ets:insert(couch_dbs_pid_to_name, {Db#db.main_pid, DbName}),
-            Lru = case couch_db:is_system_db(Db) of
-                false ->
-                    couch_lru:insert(DbName, Server#server.lru);
-                true ->
-                    Server#server.lru
-            end,
+            Lru = couch_lru:insert(DbName, Server#server.lru),
             {reply, ok, Server#server{lru = Lru}}
     end;
 handle_call({open_result, T0, DbName, {error, eexist}}, From, Server) ->
@@ -382,7 +370,7 @@ handle_call({open_result, _T0, DbName, Error}, {FromPid, _Tag}, Server) ->
                 _ ->
                     Server
             end,
-            {reply, ok, db_closed(NewServer, Db#db.options)}
+            {reply, ok, db_closed(NewServer)}
     end;
 handle_call({open, DbName, Options}, From, Server) ->
     case ets:lookup(couch_dbs, DbName) of
@@ -390,7 +378,7 @@ handle_call({open, DbName, Options}, From, Server) ->
         DbNameList = binary_to_list(DbName),
         case check_dbname(Server, DbNameList) of
         ok ->
-            case make_room(Server, Options) of
+            case maybe_close_lru_db(Server) of
             {ok, Server2} ->
                 Filepath = get_full_filename(Server, DbNameList),
                 {noreply, open_async(Server2, From, DbName, Filepath, Options)};
@@ -418,7 +406,7 @@ handle_call({create, DbName, Options}, From, Server) ->
     ok ->
         case ets:lookup(couch_dbs, DbName) of
         [] ->
-            case make_room(Server, Options) of
+            case maybe_close_lru_db(Server) of
             {ok, Server2} ->
                 {noreply, open_async(Server2, From, DbName, Filepath,
                         [create | Options])};
@@ -454,12 +442,12 @@ handle_call({delete, DbName, Options}, _From, Server) ->
             true = ets:delete(couch_dbs_pid_to_name, Pid),
             exit(Pid, kill),
             [gen_server:reply(F, not_found) || F <- Froms],
-            db_closed(Server, Db#db.options);
+            db_closed(Server);
         [#db{main_pid=Pid} = Db] ->
             true = ets:delete(couch_dbs, DbName),
             true = ets:delete(couch_dbs_pid_to_name, Pid),
             exit(Pid, kill),
-            db_closed(Server, Db#db.options)
+            db_closed(Server)
         end,
 
         %% Delete any leftover compaction files. If we don't do this a
@@ -490,10 +478,7 @@ handle_call({db_updated, #db{}=Db}, _From, Server0) ->
     Server = try ets:lookup_element(couch_dbs, DbName, #db.instance_start_time) of
         StartTime ->
             true = ets:insert(couch_dbs, Db),
-            Lru = case couch_db:is_system_db(Db) of
-                false -> couch_lru:update(DbName, Server0#server.lru);
-                true -> Server0#server.lru
-            end,
+            Lru = couch_lru:update(DbName, Server0#server.lru),
             Server0#server{lru = Lru};
         _ ->
             Server0
@@ -532,7 +517,7 @@ handle_info({'EXIT', Pid, Reason}, Server) ->
         end,
         true = ets:delete(couch_dbs, DbName),
         true = ets:delete(couch_dbs_pid_to_name, Pid),
-        {noreply, db_closed(Server, Db#db.options)};
+        {noreply, db_closed(Server)};
     [] ->
         {noreply, Server}
     end;
@@ -542,17 +527,11 @@ handle_info(restart_config_listener, State) ->
 handle_info(Info, Server) ->
     {stop, {unknown_message, Info}, Server}.
 
-db_opened(Server, Options) ->
-    case lists:member(sys_db, Options) of
-        false -> Server#server{dbs_open=Server#server.dbs_open + 1};
-        true -> Server
-    end.
+db_opened(Server) ->
+    Server#server{dbs_open=Server#server.dbs_open + 1}.
 
-db_closed(Server, Options) ->
-    case lists:member(sys_db, Options) of
-        false -> Server#server{dbs_open=Server#server.dbs_open - 1};
-        true -> Server
-    end.
+db_closed(Server) ->
+    Server#server{dbs_open=Server#server.dbs_open - 1}.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/couchdb_views_tests.erl
+++ b/test/couchdb_views_tests.erl
@@ -372,7 +372,6 @@ couchdb_1283() ->
         MonRef = erlang:monitor(process, CPid),
         Writer3 = spawn_writer(Db3#db.name),
         ?assert(is_process_alive(Writer3)),
-        ?assertEqual({error, all_dbs_active}, get_writer_status(Writer3)),
 
         ?assert(is_process_alive(Writer1)),
         ?assert(is_process_alive(Writer2)),
@@ -391,7 +390,6 @@ couchdb_1283() ->
                   {reason, "Failure compacting view group"}]})
         end,
 
-        ?assertEqual(ok, writer_try_again(Writer3)),
         ?assertEqual(ok, get_writer_status(Writer3)),
 
         ?assert(is_process_alive(Writer1)),


### PR DESCRIPTION
_replicator and _users db's have been excluded from the LRU for a long time. This is fine when you have one of each, it's not fine when you have tens of thousands of each.

Note: I've intentionally changed max_dbs_open to be a soft limit rather than a hard one. couchdb's behavior when it throws all_dbs_active is pretty poor (you can create a database that you can't open later, for example) so I think it better to remove that class of problems.

COUCHDB-3325