### PR TITLE
Add _replication_start_time to the doc field validation section.

### DIFF
--- a/src/couch_doc.erl
+++ b/src/couch_doc.erl
@@ -260,6 +260,9 @@ transfer_fields([{<<"_replication_state">>, _} = Field | Rest],
 transfer_fields([{<<"_replication_state_time">>, _} = Field | Rest],
     #doc{body=Fields} = Doc) ->
     transfer_fields(Rest, Doc#doc{body=[Field|Fields]});
+transfer_fields([{<<"_replication_start_time">>, _} = Field | Rest],
+    #doc{body=Fields} = Doc) ->
+    transfer_fields(Rest, Doc#doc{body=[Field|Fields]});
 transfer_fields([{<<"_replication_state_reason">>, _} = Field | Rest],
     #doc{body=Fields} = Doc) ->
     transfer_fields(Rest, Doc#doc{body=[Field|Fields]});


### PR DESCRIPTION
This is part of a set of PRs to merge the new scheduling replicator

Main PR is this: https://github.com/apache/couchdb-couch-replicator/pull/64

Top level PR to gather and help test all the dependencies: https://github.com/apache/couchdb/pull/454

COUCHDB-3324